### PR TITLE
Yarn/pnpm/workspace-support: Make export work

### DIFF
--- a/packages/server/src/commands/export/domain.ts
+++ b/packages/server/src/commands/export/domain.ts
@@ -26,5 +26,4 @@ export interface MetaExportFiles {
   "phero-execution.js": string
   "phero.js": string
   "package.json": string
-  "package-lock.json": string
 }

--- a/packages/server/src/commands/export/domain.ts
+++ b/packages/server/src/commands/export/domain.ts
@@ -21,9 +21,24 @@ export interface ExportFile {
   content: string
 }
 
-export interface MetaExportFiles {
-  "phero-manifest.d.ts": string
-  "phero-execution.js": string
-  "phero.js": string
-  "package.json": string
+export enum MetaExportLockFileName {
+  Npm = "package-lock.json",
+  Yarn = "yarn.lock",
+  Pnpm = "pnpm-lock.yaml",
+}
+
+export interface MetaExportLockFile {
+  name: MetaExportLockFileName
+  path: string
+}
+
+type MetaExportFileContent = string
+
+export type MetaExportFiles = {
+  "phero-manifest.d.ts": MetaExportFileContent
+  "phero-execution.js": MetaExportFileContent
+  "phero.js": MetaExportFileContent
+  "package.json": MetaExportFileContent
+} & {
+  [key in MetaExportLockFileName]?: MetaExportFileContent
 }

--- a/packages/server/src/commands/export/domain.ts
+++ b/packages/server/src/commands/export/domain.ts
@@ -27,18 +27,18 @@ export enum MetaExportLockFileName {
   Pnpm = "pnpm-lock.yaml",
 }
 
-export interface MetaExportLockFile {
-  name: MetaExportLockFileName
-  path: string
-}
-
 type MetaExportFileContent = string
 
-export type MetaExportFiles = {
+export interface MetaExportFilesBase {
   "phero-manifest.d.ts": MetaExportFileContent
   "phero-execution.js": MetaExportFileContent
   "phero.js": MetaExportFileContent
   "package.json": MetaExportFileContent
-} & {
-  [key in MetaExportLockFileName]?: MetaExportFileContent
 }
+
+export type MetaExportFiles = MetaExportFilesBase &
+  (
+    | { [MetaExportLockFileName.Npm]: MetaExportFileContent }
+    | { [MetaExportLockFileName.Yarn]: MetaExportFileContent }
+    | { [MetaExportLockFileName.Pnpm]: MetaExportFileContent }
+  )

--- a/packages/server/src/commands/export/index.ts
+++ b/packages/server/src/commands/export/index.ts
@@ -120,23 +120,23 @@ export default function exportCommand(command: ServerCommandExport) {
     "package.json": readFile(path.join(projectPath, "package.json")),
   }
   let metaExportFiles: MetaExportFiles
-  switch (lockFile[0]) {
+  switch (lockFile.name) {
     case MetaExportLockFileName.Npm:
       metaExportFiles = {
         ...metaExportFilesBase,
-        [lockFile[0]]: readFile(lockFile[1]),
+        [lockFile.name]: readFile(lockFile.path),
       }
       break
     case MetaExportLockFileName.Yarn:
       metaExportFiles = {
         ...metaExportFilesBase,
-        [lockFile[0]]: readFile(lockFile[1]),
+        [lockFile.name]: readFile(lockFile.path),
       }
       break
     case MetaExportLockFileName.Pnpm:
       metaExportFiles = {
         ...metaExportFilesBase,
-        [lockFile[0]]: readFile(lockFile[1]),
+        [lockFile.name]: readFile(lockFile.path),
       }
       break
   }
@@ -217,20 +217,20 @@ export default function exportCommand(command: ServerCommandExport) {
 
 function findLockFileInDir(
   dir: string,
-): [name: MetaExportLockFileName, path: string] | undefined {
+): { name: MetaExportLockFileName; path: string } | undefined {
   const lockFilePath = path.join(dir, MetaExportLockFileName.Npm)
   if (fs.existsSync(lockFilePath)) {
-    return [MetaExportLockFileName.Npm, lockFilePath]
+    return { name: MetaExportLockFileName.Npm, path: lockFilePath }
   }
 
   const yarnLockFilePath = path.join(dir, MetaExportLockFileName.Yarn)
   if (fs.existsSync(yarnLockFilePath)) {
-    return [MetaExportLockFileName.Yarn, yarnLockFilePath]
+    return { name: MetaExportLockFileName.Yarn, path: yarnLockFilePath }
   }
 
   const pnpmLockFilePath = path.join(dir, MetaExportLockFileName.Pnpm)
   if (fs.existsSync(pnpmLockFilePath)) {
-    return [MetaExportLockFileName.Pnpm, pnpmLockFilePath]
+    return { name: MetaExportLockFileName.Pnpm, path: pnpmLockFilePath }
   }
 
   return undefined
@@ -238,7 +238,7 @@ function findLockFileInDir(
 
 function findLockFileForWorkspace(
   projectPath: string,
-): [name: MetaExportLockFileName, path: string] | undefined {
+): { name: MetaExportLockFileName; path: string } | undefined {
   const maxDepth = 5
 
   let currentPath = projectPath

--- a/packages/server/src/commands/export/index.ts
+++ b/packages/server/src/commands/export/index.ts
@@ -120,6 +120,11 @@ export default function exportCommand(command: ServerCommandExport) {
         return yarnLockFilePath
       }
 
+      const pnpmLockFilePath = path.join(currentPath, "pnpm-lock.yaml")
+      if (fs.existsSync(pnpmLockFilePath)) {
+        return pnpmLockFilePath
+      }
+
       currentPath = path.join(currentPath, "..")
     }
 

--- a/packages/server/src/commands/export/index.ts
+++ b/packages/server/src/commands/export/index.ts
@@ -109,7 +109,7 @@ export default function exportCommand(command: ServerCommandExport) {
 
   if (!lockFile) {
     throw new Error(
-      "No lockfile found in the current directory or for any workspace",
+      "No lockfile ('package-lock.json', 'yarn.lock' or 'pnpm-lock.yaml') found in the current directory or for any workspace",
     )
   }
 


### PR DESCRIPTION
- We now also search for a `yarn.lock` file
- If we can't find a `lock` file in the server directory we go up a maximum of 5 levels to find it. This allows the export to be used in a `workspaces` setup.