### PR TITLE
Make `npx phero` run on Windows

### DIFF
--- a/packages/cli/src/process.ts
+++ b/packages/cli/src/process.ts
@@ -20,7 +20,7 @@ export function spawnClientDevEnv(
   cwd: string,
 ): ChildProcess {
   const argv = ["exec", "--", "phero-client", "watch", `--port=${command.port}`]
-  const createdChildProcess = spawn("npm", argv, { cwd })
+  const createdChildProcess = spawn("npm", argv, { cwd, shell: true })
   return handleDevEnvChildProcess(createdChildProcess, "phero-client")
 }
 
@@ -30,7 +30,7 @@ export function spawnServerDevEnv(
   onLog: (data: string) => void,
 ): ChildProcess {
   const argv = ["exec", "--", "phero-server", "serve", `--port=${command.port}`]
-  const createdChildProcess = spawn("npm", argv, { cwd })
+  const createdChildProcess = spawn("npm", argv, { cwd, shell: true })
 
   createdChildProcess.stdout.on("data", (data) =>
     onLog?.(data.toString().trim()),


### PR DESCRIPTION
TIL: Windows needs `shell: true` when using `spawn` ([discussion](https://stackoverflow.com/a/54515183/636778). There's also a [`cross-spawn` package](https://www.npmjs.com/package/cross-spawn), which solves this and more issues, but it as far as I know this is all we need at the moment. Let's add that when we hit more issues like this. 

Fixes #99.