### PR TITLE
Hotfix/0.10.0 alpha hotfixes

### DIFF
--- a/packages/core/src/generateManifest/__tests__/__snapshots__/generateManifest.test.ts.snap
+++ b/packages/core/src/generateManifest/__tests__/__snapshots__/generateManifest.test.ts.snap
@@ -75,18 +75,18 @@ export class articleService extends PheroService<{
 `;
 
 exports[`generateManifest typeAliases jasper 1`] = `
-"export interface X {
+"export interface A {
+    b: B;
+}
+export interface B {
+    [key: string]: Z;
+}
+export type Z = X | Y;
+export interface X {
     type: "x";
 }
 export interface Y {
     type: "y";
-}
-export type Z = X | Y;
-export interface B {
-    [key: string]: Z;
-}
-export interface A {
-    b: B;
 }
 export abstract class PheroService<TContext = {}> {
 }
@@ -116,11 +116,11 @@ export class articleService extends PheroService {
 `;
 
 exports[`generateManifest typeAliases type aliases which are aliases of aliases 1`] = `
-"export type TypeReal = {
+"export type Result = TypeRef;
+export type TypeRef = TypeReal;
+export type TypeReal = {
     x: number;
 };
-export type TypeRef = TypeReal;
-export type Result = TypeRef;
 export abstract class PheroService<TContext = {}> {
 }
 export class workoutRoutineService extends PheroService {

--- a/packages/core/src/generateModel/__tests__/union.test.ts
+++ b/packages/core/src/generateModel/__tests__/union.test.ts
@@ -143,4 +143,47 @@ describe("union", () => {
       },
     })
   })
+  test("InterfaceOne | null", () => {
+    try {
+      const modelMap = generateParserModelForReturnType(`
+        interface InterfaceOne {
+          prop: 1
+        }
+        function test(): InterfaceOne | null { throw new Error() }
+    `)
+
+      expect(modelMap).toEqual({
+        root: {
+          type: "union",
+          oneOf: [
+            {
+              type: "reference",
+              typeName: "InterfaceOne",
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+        deps: {
+          InterfaceOne: {
+            type: "object",
+            members: [
+              {
+                type: "member",
+                name: "prop",
+                optional: false,
+                parser: { type: "number-literal", literal: 1 },
+              },
+            ],
+          },
+        },
+      })
+    } catch (e) {
+      console.error(
+        typeof e === "object" && e !== null && "stack" in e ? e.stack : "",
+      )
+      throw e
+    }
+  })
 })

--- a/packages/core/src/generateModel/generateFromTypeNode/generateFromUnionTypeNode.ts
+++ b/packages/core/src/generateModel/generateFromTypeNode/generateFromUnionTypeNode.ts
@@ -18,7 +18,7 @@ export default function generateFromUnionTypeNode(
     ({ oneOf, deps }, subtype, index) => {
       const subtypeModel = generateFromTypeNode(
         subtype,
-        type.types[index],
+        typeChecker.getTypeAtLocation(subtype),
         location,
         typeChecker,
         deps,


### PR DESCRIPTION
This is a fix for a bug in the `@phero/server@0.10.0-alpha.0` release. When combining unions with a `null` element in borked. An example:

```
 interface InterfaceOne {
  prop: 1
}
function test(): InterfaceOne | null { throw new Error() }
```
This fixes that. 
Alongside with an updated version of a snaphot test (unrelated 😅).
