### PR TITLE
Fixes type parameters icw. conditional types

### DIFF
--- a/packages/core/src/generateModel/__tests__/conditional.test.ts
+++ b/packages/core/src/generateModel/__tests__/conditional.test.ts
@@ -559,7 +559,7 @@ describe("conditional", () => {
       }
       function test(): MyConditionalType<number, Hop<number>> { throw new Error() }
     `)
-
+    // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
         type: "reference",
@@ -642,6 +642,343 @@ describe("conditional", () => {
                       type: "number",
                     },
                   ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+  test("MyConditionalType<boolean>", () => {
+    const modelMap = generateParserModelForReturnType(`
+      type MyConditionalType<T, K> = T extends string ? {
+        prop: number
+        x: K
+      } : {
+        prop: string
+        x: K
+      }
+      interface Hop<H> {
+        h: H
+      }
+      function test(): MyConditionalType<boolean, Hop<number>> { throw new Error() }
+    `)
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "MyConditionalType<boolean, Hop<number>>",
+        typeArguments: [
+          {
+            type: "boolean",
+          },
+          {
+            type: "reference",
+            typeName: "Hop<number>",
+            typeArguments: [
+              {
+                type: "number",
+              },
+            ],
+          },
+        ],
+      },
+      deps: {
+        "Hop<number>": {
+          type: "generic",
+          typeName: "Hop<number>",
+          typeArguments: [
+            {
+              type: "number",
+            },
+          ],
+          parser: {
+            type: "object",
+            members: [
+              {
+                type: "member",
+                name: "h",
+                optional: false,
+                parser: {
+                  type: "number",
+                },
+              },
+            ],
+          },
+        },
+        "MyConditionalType<boolean, Hop<number>>": {
+          type: "generic",
+          typeName: "MyConditionalType<boolean, Hop<number>>",
+          typeArguments: [
+            {
+              type: "boolean",
+            },
+            {
+              type: "reference",
+              typeName: "Hop<number>",
+              typeArguments: [
+                {
+                  type: "number",
+                },
+              ],
+            },
+          ],
+          parser: {
+            type: "object",
+            members: [
+              {
+                type: "member",
+                name: "prop",
+                optional: false,
+                parser: {
+                  type: "string",
+                },
+              },
+              {
+                type: "member",
+                name: "x",
+                optional: false,
+                parser: {
+                  type: "reference",
+                  typeName: "Hop<number>",
+                  typeArguments: [
+                    {
+                      type: "number",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+  test("a conditional type with or without a declared type should work the same", () => {
+    const modelMapA = generateParserModelForReturnType(`
+      type MyConditionalType<T, K> = T extends string ? RRR<number, K> : RRR<string, K>;
+      interface RRR<X, Y> {
+          prop: X;
+          x: Y;
+      }
+      interface Hop<H> {
+        h: H
+      }
+      function test(): MyConditionalType<boolean, Hop<number>> { throw new Error() }
+    `)
+
+    const modelMapB = generateParserModelForReturnType(`
+      type MyConditionalType<T, K> = T extends string ? {
+        prop: number
+        x: K
+      } : {
+        prop: string
+        x: K
+      }
+      interface Hop<H> {
+        h: H
+      }
+      function test(): MyConditionalType<boolean, Hop<number>> { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMapA).toEqual(modelMapB)
+  })
+  test("ConditionalType with reference with default param", () => {
+    const modelMap = generateParserModelForReturnType(`
+      type MyConditionalType<K> = K extends string ? TheInterface : never
+
+      type TheInterface<T = boolean> = {
+        prop: T
+      }
+
+      function test(): MyConditionalType<string> { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "MyConditionalType<string>",
+        typeArguments: [
+          {
+            type: "string",
+          },
+        ],
+      },
+      deps: {
+        "MyConditionalType<string>": {
+          type: "generic",
+          typeArguments: [
+            {
+              type: "string",
+            },
+          ],
+          typeName: "MyConditionalType<string>",
+          parser: {
+            type: "object",
+            members: [
+              {
+                type: "member",
+                name: "prop",
+                optional: false,
+                parser: {
+                  type: "boolean",
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+  test("ConditionalType with reference with given param", () => {
+    const modelMap = generateParserModelForReturnType(`
+      type MyConditionalType<K> = K extends string ? TheInterface<number> : never
+
+      interface TheInterface<T = boolean> {
+        prop: T
+      }
+
+      function test(): MyConditionalType<string> { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "MyConditionalType<string>",
+        typeArguments: [
+          {
+            type: "string",
+          },
+        ],
+      },
+      deps: {
+        "MyConditionalType<string>": {
+          type: "generic",
+          typeArguments: [
+            {
+              type: "string",
+            },
+          ],
+          typeName: "MyConditionalType<string>",
+          parser: {
+            type: "object",
+            members: [
+              {
+                type: "member",
+                name: "prop",
+                optional: false,
+                parser: {
+                  type: "number",
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  test("ConditionalType with reference with given param", () => {
+    const modelMap = generateParserModelForReturnType(`
+      type MyConditional<K, P = K extends string ? number : never> = {
+        prop: P
+      }
+
+      interface TheInterface<T = string> {
+        prop: T
+      }
+
+      function test(): MyConditional<string> { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "MyConditional<string, number>",
+        typeArguments: [
+          {
+            type: "string",
+          },
+          {
+            type: "number",
+          },
+        ],
+      },
+      deps: {
+        "MyConditional<string, number>": {
+          type: "generic",
+          typeArguments: [
+            {
+              type: "string",
+            },
+            {
+              type: "number",
+            },
+          ],
+          typeName: "MyConditional<string, number>",
+          parser: {
+            type: "object",
+            members: [
+              {
+                type: "member",
+                name: "prop",
+                optional: false,
+                parser: {
+                  type: "number",
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  test("ConditionalType with reference with given param", () => {
+    const modelMap = generateParserModelForReturnType(`
+      type MyConditional<K> = K extends string ? TheInterface<number> : never
+
+      interface TheInterface<T = string> {
+        prop: T
+      }
+
+      function test(): MyConditional<string> { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "MyConditional<string>",
+        typeArguments: [
+          {
+            type: "string",
+          },
+        ],
+      },
+      deps: {
+        "MyConditional<string>": {
+          type: "generic",
+          typeArguments: [
+            {
+              type: "string",
+            },
+          ],
+          typeName: "MyConditional<string>",
+          parser: {
+            type: "object",
+            members: [
+              {
+                type: "member",
+                name: "prop",
+                optional: false,
+                parser: {
+                  type: "number",
                 },
               },
             ],

--- a/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
+++ b/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
@@ -6,8 +6,8 @@ import {
 } from ".."
 import { PheroParseError } from "../../domain/errors"
 import {
-  type ParserModel,
   ParserModelType,
+  type ParserModel,
   type ReferenceParserModel,
 } from "../../domain/ParserModel"
 import generateFromType from "../generateFromType"
@@ -195,26 +195,45 @@ function generateFromDeclarationWithDeclaration(
       updatedDeps,
       ref,
       (updatedDeps) => {
-        return isEventuallyMappedOrConditionalTypeNode(
-          declaration.type,
-          typeChecker,
-        )
-          ? generateFromType(
-              type,
-              declaration.type,
-              location,
-              typeChecker,
-              updatedDeps,
-              updatedTypeParams,
-            )
-          : generateFromTypeNode(
-              declaration.type,
-              type,
-              location,
-              typeChecker,
-              updatedDeps,
-              updatedTypeParams,
-            )
+        if (ts.isConditionalTypeNode(declaration.type)) {
+          const conditionalTypeParams = rewriteTypeParamsForConditionalType(
+            declaration.type,
+            type,
+            location,
+            typeChecker,
+            updatedTypeParams,
+            updatedDeps,
+          )
+
+          return generateFromTypeNode(
+            declaration.type,
+            type,
+            location,
+            typeChecker,
+            conditionalTypeParams.deps,
+            conditionalTypeParams.typeParams,
+          )
+        } else if (
+          isEventuallyMappedOrConditionalTypeNode(declaration.type, typeChecker)
+        ) {
+          return generateFromType(
+            type,
+            declaration.type,
+            location,
+            typeChecker,
+            updatedDeps,
+            updatedTypeParams,
+          )
+        } else {
+          return generateFromTypeNode(
+            declaration.type,
+            type,
+            location,
+            typeChecker,
+            updatedDeps,
+            updatedTypeParams,
+          )
+        }
       },
     )
 
@@ -299,14 +318,20 @@ function getUpdatedTypeParams(
     type.aliasTypeArguments ?? typeChecker.getTypeArguments(type)
   const typeArguments = typeNode.typeArguments ?? []
 
+  const isTypeNodeConditionalType = isEventuallyConditionalTypeNode(
+    typeNode,
+    typeChecker,
+  )
+
   for (let i = 0; i < declaration.typeParameters.length; i++) {
     const typeParam = declaration.typeParameters[i]
     const typeArgument = typeArguments[i]
 
     // type parameter has an argument
     if (typeArgument) {
-      const typeArgumentType =
-        typeArgumentTypes[i] ?? typeChecker.getTypeAtLocation(typeArgument)
+      const typeArgumentType = isTypeNodeConditionalType
+        ? typeChecker.getTypeAtLocation(typeArgument)
+        : typeArgumentTypes[i] ?? typeChecker.getTypeAtLocation(typeArgument)
 
       // argument refers to another type parameter
       if (typeArgumentType.isTypeParameter()) {
@@ -475,4 +500,105 @@ function isEventuallyMappedOrConditionalTypeNode(
   }
 
   return false
+}
+
+function isEventuallyConditionalTypeNode(
+  node: ts.Node,
+  typeChecker: ts.TypeChecker,
+): boolean {
+  if (ts.isConditionalTypeNode(node)) {
+    return true
+  }
+
+  if (ts.isTypeAliasDeclaration(node)) {
+    return isEventuallyConditionalTypeNode(node.type, typeChecker)
+  }
+
+  if (ts.isTypeReferenceNode(node)) {
+    const d = getDeclaration(node, typeChecker)
+    return isEventuallyConditionalTypeNode(d, typeChecker)
+  }
+
+  return false
+}
+
+/**
+ * We need this extra function for conditional types to generate the model for
+ * type parameters of the conditional type.
+ *
+ * Example:
+ * ```
+ *   type MyConditionalType<A> = A extends string ? B : never
+ *   type B<T = string> = { prop: T }
+ * ```
+ * In this case B has a type parameter which is by default string. The TS compiler
+ * returns the type of B when we acquire the type of MyConditionalType. When we then try
+ * to generate the model of prop with type T, we don't have it yet because the conditional
+ * TypeNode step was skipped.
+ * @returns The correct TypeParamMap for a ConditionalTypeNode
+ */
+function rewriteTypeParamsForConditionalType(
+  conditionalTypeNode: ts.ConditionalTypeNode,
+  type: ts.TypeReference,
+  location: ts.TypeNode,
+  typeChecker: ts.TypeChecker,
+  typeParams: TypeParamMap,
+  deps: DependencyMap,
+): { typeParams: TypeParamMap; deps: DependencyMap } {
+  const typeParameterDeclarations =
+    typeChecker.symbolToTypeParameterDeclarations(
+      type.aliasSymbol ?? type.symbol,
+      conditionalTypeNode,
+      undefined,
+    )
+
+  if (!typeParameterDeclarations || typeParameterDeclarations.length === 0) {
+    return { typeParams, deps }
+  }
+
+  const updatedTypeParams: TypeParamMap = new Map([...typeParams])
+  let updatedDeps: DependencyMap = deps
+
+  const typeArguments =
+    type.aliasTypeArguments ?? typeChecker.getTypeArguments(type)
+  for (let i = 0; i < typeParameterDeclarations.length; i++) {
+    const typeParamDeclr = typeParameterDeclarations[i]
+    const typeArgument = typeArguments[i]
+    const typeArgString = typeChecker.typeToString(typeArgument)
+    const existingDep = updatedDeps.get(typeArgString)
+    if (existingDep) {
+      if (existingDep.type === ParserModelType.Generic) {
+        updatedTypeParams.set(typeParamDeclr.name.text, {
+          name: typeArgString,
+          model: {
+            type: ParserModelType.Reference,
+            typeName: existingDep.typeName,
+            typeArguments: existingDep.typeArguments,
+          },
+        })
+      } else {
+        updatedTypeParams.set(typeParamDeclr.name.text, {
+          name: typeArgString,
+          model: existingDep,
+        })
+      }
+    } else {
+      const typeModel = generateFromType(
+        typeArgument,
+        conditionalTypeNode,
+        location,
+        typeChecker,
+        deps,
+        updatedTypeParams,
+      )
+
+      updatedTypeParams.set(typeParamDeclr.name.text, {
+        name: typeArgString,
+        model: typeModel.root,
+      })
+      updatedDeps = typeModel.deps
+    }
+  }
+
+  return { typeParams: updatedTypeParams, deps: updatedDeps }
 }


### PR DESCRIPTION
Fixes a bug with conditional types: when the trueType had type parameters they were not generated by us.

Example:
```
  type MyConditionalType<A> = A extends string ? B : never
  type B<T = string> = { prop: T }
```

In this case B has a type parameter which is by default string. The TS compiler returns the type of B when we acquire the type of MyConditionalType. When we then try to generate the model of prop with type T, we don't have it yet because the conditional TypeNode step was skipped.