### PR TITLE
typeRef names in generated manifest should be stripped and clean

### DIFF
--- a/packages/core/src/generateManifest/__tests__/generateManifest.test.ts
+++ b/packages/core/src/generateManifest/__tests__/generateManifest.test.ts
@@ -13,7 +13,7 @@ function generate(prog: ts.Program): string {
 
   const parsedApp = parsePheroApp(prog)
 
-  return generateManifest(parsedApp).content
+  return generateManifest(parsedApp, prog.getTypeChecker()).content
 }
 
 describe("generateManifest", () => {

--- a/packages/core/src/generateManifest/generateFunctionDeclaration.ts
+++ b/packages/core/src/generateManifest/generateFunctionDeclaration.ts
@@ -1,10 +1,12 @@
 import type ts from "typescript"
 import { type PheroFunction } from "../domain/PheroApp"
+import cleanTypeReferences from "../lib/cleanTypeReferences"
 import cloneTS from "../lib/cloneTS"
 import * as tsx from "../tsx"
 
 export default function generateFunctionDeclaration(
   func: PheroFunction,
+  typeChecker: ts.TypeChecker,
 ): ts.MethodDeclaration {
   return tsx.method({
     name: func.name,
@@ -12,12 +14,12 @@ export default function generateFunctionDeclaration(
       tsx.param({
         name: param.name,
         questionToken: param.questionToken,
-        type: cloneTS(param.type),
+        type: cleanTypeReferences(cloneTS(param.type), typeChecker),
       }),
     ),
     returnType: tsx.type.reference({
       name: "Promise",
-      args: [cloneTS(func.returnType)],
+      args: [cleanTypeReferences(cloneTS(func.returnType), typeChecker)],
     }),
   })
 }

--- a/packages/core/src/lib/cleanTypeReferences.ts
+++ b/packages/core/src/lib/cleanTypeReferences.ts
@@ -1,0 +1,44 @@
+import ts from "typescript"
+
+export default function cleanTypeReferences<TNode extends ts.Node>(
+  rootNode: TNode,
+  typeChecker: ts.TypeChecker,
+): TNode {
+  const transformer =
+    <T extends ts.Node>(context: ts.TransformationContext) =>
+    (rootNode: T) => {
+      function visit(node: ts.Node): ts.Node {
+        if (ts.isTypeReferenceNode(node)) {
+          return cleanTypeNames(node, typeChecker)
+        }
+        return ts.visitEachChild(node, visit, context)
+      }
+      return ts.visitNode(rootNode, visit)
+    }
+
+  return ts.transform<TNode>(rootNode, [transformer]).transformed[0]
+}
+
+function cleanTypeNames(
+  typeNode: ts.TypeNode,
+  typeChecker: ts.TypeChecker,
+): ts.TypeNode {
+  if (!ts.isTypeReferenceNode(typeNode)) {
+    return typeNode
+  }
+
+  const type = typeChecker.getTypeAtLocation(typeNode.typeName)
+  const declr = (type.aliasSymbol ?? type.symbol)?.declarations?.[0]
+  if (!declr || ts.isEnumMember(declr)) {
+    return typeNode
+  }
+
+  return ts.factory.createTypeReferenceNode(
+    ts.isQualifiedName(typeNode.typeName)
+      ? typeNode.typeName.right
+      : typeNode.typeName,
+    typeNode.typeArguments?.map((typeArg) =>
+      cleanTypeNames(typeArg, typeChecker),
+    ),
+  )
+}

--- a/packages/server/src/commands/build.ts
+++ b/packages/server/src/commands/build.ts
@@ -68,7 +68,7 @@ export default function buildCommand(command: ServerCommandBuild) {
   })
 
   const app = parsePheroApp(program)
-  const { content: dts } = generateManifest(app)
+  const { content: dts } = generateManifest(app, program.getTypeChecker())
   const manifestPath = path.join(projectPath, "phero-manifest.d.ts")
   fs.writeFileSync(manifestPath, dts)
 }

--- a/packages/server/src/commands/export/index.ts
+++ b/packages/server/src/commands/export/index.ts
@@ -93,7 +93,7 @@ export default function exportCommand(command: ServerCommandExport) {
   program.emit()
 
   const app = parsePheroApp(program)
-  const { content: dts } = generateManifest(app)
+  const { content: dts } = generateManifest(app, program.getTypeChecker())
   const pheroExecution = generatePheroExecutionFile(app)
 
   const lockFile =

--- a/packages/server/src/commands/serve/DevServer.ts
+++ b/packages/server/src/commands/serve/DevServer.ts
@@ -103,7 +103,7 @@ export default class DevServer {
     try {
       this.eventEmitter.emit({ type: "BUILD_MANIFEST_START" })
       app = parsePheroApp(prog)
-      const { content: dts } = generateManifest(app)
+      const { content: dts } = generateManifest(app, prog.getTypeChecker())
       await fs.writeFile(this.manifestPath, dts)
       this.eventEmitter.emit({ type: "BUILD_MANIFEST_SUCCESS" })
     } catch (error) {


### PR DESCRIPTION
Type references can hold namespace like prefixes. We make sure to strip those before while generating the manifest.