### PR TITLE
Hotfix/fix model extracting

### DIFF
--- a/packages/core/src/generateManifest/__tests__/__snapshots__/generateManifest.test.ts.snap
+++ b/packages/core/src/generateManifest/__tests__/__snapshots__/generateManifest.test.ts.snap
@@ -62,10 +62,7 @@ export class articleService extends PheroService {
 `;
 
 exports[`generateManifest middleware should parse middleware 1`] = `
-"export interface User {
-    uid: string;
-}
-export abstract class PheroService<TContext = {}> {
+"export abstract class PheroService<TContext = {}> {
 }
 export class articleService extends PheroService<{
     uid: string;

--- a/packages/core/src/parsePheroApp/parsePheroApp.ts
+++ b/packages/core/src/parsePheroApp/parsePheroApp.ts
@@ -80,7 +80,7 @@ export function parsePheroApp(prog: ts.Program): PheroApp {
     ...pheroServices.flatMap((service) => [
       ...service.funcs.flatMap((func) => parseFunctionModels(func, prog)),
       ...(service.config.middleware
-        ? parseMiddlewareModels(service.config.middleware, prog)
+        ? parseMiddlewareModels(service.config, prog)
         : []),
     ]),
     ...parseErrorModels([...errorMap.values()], prog),


### PR DESCRIPTION
This fixes 2 issues:

1. External models (coming from other *.d.ts files) were not included in the manifest. These are now included.
2. We only extract the models from middleware context what the client actually needs.