### PR TITLE
inline conditional types

### DIFF
--- a/packages/core/src/generateModel/__tests__/conditional.test.ts
+++ b/packages/core/src/generateModel/__tests__/conditional.test.ts
@@ -13,34 +13,19 @@ describe("conditional", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyConditionalType<number>",
-        typeArguments: [{ type: "number" }],
-      },
-      deps: {
-        "MyConditionalType<number>": {
-          type: "generic",
-          typeName: "MyConditionalType<number>",
-          typeArguments: [
-            {
-              type: "number",
+        type: "object",
+        members: [
+          {
+            type: "member",
+            name: "prop",
+            optional: false,
+            parser: {
+              type: "string",
             },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "string",
-                },
-              },
-            ],
           },
-        },
+        ],
       },
+      deps: {},
     })
   })
   test("MyConditionalType<string>", () => {
@@ -52,36 +37,22 @@ describe("conditional", () => {
       }
       function test(): MyConditionalType<string> { throw new Error() }
     `)
+    // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyConditionalType<string>",
-        typeArguments: [{ type: "string" }],
-      },
-      deps: {
-        "MyConditionalType<string>": {
-          type: "generic",
-          typeName: "MyConditionalType<string>",
-          typeArguments: [
-            {
-              type: "string",
+        type: "object",
+        members: [
+          {
+            type: "member",
+            name: "prop",
+            optional: false,
+            parser: {
+              type: "number",
             },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "number",
-                },
-              },
-            ],
           },
-        },
+        ],
       },
+      deps: {},
     })
   })
   test("MyDeepConditionalType<number>", () => {
@@ -99,7 +70,7 @@ describe("conditional", () => {
 
       function test(): MyDeepConditionalType<number> { throw new Error() }
     `)
-
+    // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
         type: "reference",
@@ -131,31 +102,17 @@ describe("conditional", () => {
                 name: "deep",
                 optional: false,
                 parser: {
-                  type: "reference",
-                  typeName: "DeepCondition<string>",
-                  typeArguments: [{ type: "string" }],
-                },
-              },
-            ],
-          },
-        },
-        "DeepCondition<string>": {
-          type: "generic",
-          typeName: "DeepCondition<string>",
-          typeArguments: [
-            {
-              type: "string",
-            },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "number",
+                  type: "object",
+                  members: [
+                    {
+                      type: "member",
+                      name: "prop",
+                      optional: false,
+                      parser: {
+                        type: "number",
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -202,31 +159,17 @@ describe("conditional", () => {
                 name: "deep",
                 optional: false,
                 parser: {
-                  type: "reference",
-                  typeName: "DeepCondition<number>",
-                  typeArguments: [{ type: "number" }],
-                },
-              },
-            ],
-          },
-        },
-        "DeepCondition<number>": {
-          type: "generic",
-          typeName: "DeepCondition<number>",
-          typeArguments: [
-            {
-              type: "number",
-            },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "string",
+                  type: "object",
+                  members: [
+                    {
+                      type: "member",
+                      name: "prop",
+                      optional: false,
+                      parser: {
+                        type: "string",
+                      },
+                    },
+                  ],
                 },
               },
             ],
@@ -301,7 +244,6 @@ describe("conditional", () => {
       },
     })
   })
-
   test("MyDeepConditionalRecursiveType<number>", () => {
     const modelMap = generateParserModelForReturnType(`
       interface MyDeepConditionalRecursiveType<T> {
@@ -562,92 +504,37 @@ describe("conditional", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyConditionalType<number, Hop<number>>",
-        typeArguments: [
+        type: "object",
+        members: [
           {
-            type: "number",
+            type: "member",
+            name: "prop",
+            optional: false,
+            parser: {
+              type: "string",
+            },
           },
           {
-            type: "reference",
-            typeName: "Hop<number>",
-            typeArguments: [
-              {
-                type: "number",
-              },
-            ],
-          },
-        ],
-      },
-      deps: {
-        "Hop<number>": {
-          type: "generic",
-          typeName: "Hop<number>",
-          typeArguments: [
-            {
-              type: "number",
-            },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "h",
-                optional: false,
-                parser: {
-                  type: "number",
-                },
-              },
-            ],
-          },
-        },
-        "MyConditionalType<number, Hop<number>>": {
-          type: "generic",
-          typeName: "MyConditionalType<number, Hop<number>>",
-          typeArguments: [
-            {
-              type: "number",
-            },
-            {
-              type: "reference",
-              typeName: "Hop<number>",
-              typeArguments: [
+            type: "member",
+            name: "x",
+            optional: false,
+            parser: {
+              type: "object",
+              members: [
                 {
-                  type: "number",
+                  type: "member",
+                  name: "h",
+                  optional: false,
+                  parser: {
+                    type: "number",
+                  },
                 },
               ],
             },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "string",
-                },
-              },
-              {
-                type: "member",
-                name: "x",
-                optional: false,
-                parser: {
-                  type: "reference",
-                  typeName: "Hop<number>",
-                  typeArguments: [
-                    {
-                      type: "number",
-                    },
-                  ],
-                },
-              },
-            ],
           },
-        },
+        ],
       },
+      deps: {},
     })
   })
   test("MyConditionalType<boolean>", () => {
@@ -667,92 +554,37 @@ describe("conditional", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyConditionalType<boolean, Hop<number>>",
-        typeArguments: [
+        type: "object",
+        members: [
           {
-            type: "boolean",
+            type: "member",
+            name: "prop",
+            optional: false,
+            parser: {
+              type: "string",
+            },
           },
           {
-            type: "reference",
-            typeName: "Hop<number>",
-            typeArguments: [
-              {
-                type: "number",
-              },
-            ],
-          },
-        ],
-      },
-      deps: {
-        "Hop<number>": {
-          type: "generic",
-          typeName: "Hop<number>",
-          typeArguments: [
-            {
-              type: "number",
-            },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "h",
-                optional: false,
-                parser: {
-                  type: "number",
-                },
-              },
-            ],
-          },
-        },
-        "MyConditionalType<boolean, Hop<number>>": {
-          type: "generic",
-          typeName: "MyConditionalType<boolean, Hop<number>>",
-          typeArguments: [
-            {
-              type: "boolean",
-            },
-            {
-              type: "reference",
-              typeName: "Hop<number>",
-              typeArguments: [
+            type: "member",
+            name: "x",
+            optional: false,
+            parser: {
+              type: "object",
+              members: [
                 {
-                  type: "number",
+                  type: "member",
+                  name: "h",
+                  optional: false,
+                  parser: {
+                    type: "number",
+                  },
                 },
               ],
             },
-          ],
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "string",
-                },
-              },
-              {
-                type: "member",
-                name: "x",
-                optional: false,
-                parser: {
-                  type: "reference",
-                  typeName: "Hop<number>",
-                  typeArguments: [
-                    {
-                      type: "number",
-                    },
-                  ],
-                },
-              },
-            ],
           },
-        },
+        ],
       },
+      deps: {},
     })
   })
   test("a conditional type with or without a declared type should work the same", () => {
@@ -799,38 +631,19 @@ describe("conditional", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyConditionalType<string>",
-        typeArguments: [
+        type: "object",
+        members: [
           {
-            type: "string",
+            type: "member",
+            name: "prop",
+            optional: false,
+            parser: {
+              type: "boolean",
+            },
           },
         ],
       },
-      deps: {
-        "MyConditionalType<string>": {
-          type: "generic",
-          typeArguments: [
-            {
-              type: "string",
-            },
-          ],
-          typeName: "MyConditionalType<string>",
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "boolean",
-                },
-              },
-            ],
-          },
-        },
-      },
+      deps: {},
     })
   })
   test("ConditionalType with reference with given param", () => {
@@ -847,41 +660,21 @@ describe("conditional", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyConditionalType<string>",
-        typeArguments: [
+        type: "object",
+        members: [
           {
-            type: "string",
+            type: "member",
+            name: "prop",
+            optional: false,
+            parser: {
+              type: "number",
+            },
           },
         ],
       },
-      deps: {
-        "MyConditionalType<string>": {
-          type: "generic",
-          typeArguments: [
-            {
-              type: "string",
-            },
-          ],
-          typeName: "MyConditionalType<string>",
-          parser: {
-            type: "object",
-            members: [
-              {
-                type: "member",
-                name: "prop",
-                optional: false,
-                parser: {
-                  type: "number",
-                },
-              },
-            ],
-          },
-        },
-      },
+      deps: {},
     })
   })
-
   test("ConditionalType with reference with given param", () => {
     const modelMap = generateParserModelForReturnType(`
       type MyConditional<K, P = K extends string ? number : never> = {
@@ -938,7 +731,6 @@ describe("conditional", () => {
       },
     })
   })
-
   test("ConditionalType with reference with given param", () => {
     const modelMap = generateParserModelForReturnType(`
       type MyConditional<K> = K extends string ? TheInterface<number> : never
@@ -953,24 +745,38 @@ describe("conditional", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyConditional<string>",
-        typeArguments: [
+        type: "object",
+        members: [
           {
-            type: "string",
+            type: "member",
+            name: "prop",
+            optional: false,
+            parser: {
+              type: "number",
+            },
           },
         ],
       },
-      deps: {
-        "MyConditional<string>": {
-          type: "generic",
-          typeArguments: [
-            {
-              type: "string",
-            },
-          ],
-          typeName: "MyConditional<string>",
-          parser: {
+      deps: {},
+    })
+  })
+  test("ConditionalType with reference with given param", () => {
+    const modelMap = generateParserModelForReturnType(`
+      type MyConditional<K> = K extends string ? TheInterface<number> | number : never
+
+      interface TheInterface<X = boolean> {
+        prop: X
+      }
+
+      function test(): MyConditional<string> { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "union",
+        oneOf: expect.arrayContaining([
+          {
             type: "object",
             members: [
               {
@@ -983,8 +789,12 @@ describe("conditional", () => {
               },
             ],
           },
-        },
+          {
+            type: "number",
+          },
+        ]),
       },
+      deps: {},
     })
   })
 })

--- a/packages/core/src/generateModel/__tests__/mapped.test.ts
+++ b/packages/core/src/generateModel/__tests__/mapped.test.ts
@@ -342,15 +342,10 @@ describe("mapped", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "MyMappedType",
+        type: "string-literal",
+        literal: "kaas",
       },
-      deps: {
-        MyMappedType: {
-          type: "string-literal",
-          literal: "kaas",
-        },
-      },
+      deps: {},
     })
   })
   test("Pick", () => {

--- a/packages/core/src/generateModel/__tests__/tuple.test.ts
+++ b/packages/core/src/generateModel/__tests__/tuple.test.ts
@@ -716,30 +716,25 @@ describe("tuple", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(modelMap).toEqual({
       root: {
-        type: "reference",
-        typeName: "X",
-      },
-      deps: {
-        X: {
-          type: "tuple",
-          elements: [
-            {
-              type: "tupleElement",
-              position: 0,
-              parser: {
-                type: "number",
-              },
+        type: "tuple",
+        elements: [
+          {
+            type: "tupleElement",
+            position: 0,
+            parser: {
+              type: "number",
             },
-            {
-              type: "tupleElement",
-              position: 1,
-              parser: {
-                type: "number",
-              },
+          },
+          {
+            type: "tupleElement",
+            position: 1,
+            parser: {
+              type: "number",
             },
-          ],
-        },
+          },
+        ],
       },
+      deps: {},
     })
   })
 })

--- a/packages/core/src/generateParser/__tests__/code-gen/conditional.test.ts
+++ b/packages/core/src/generateParser/__tests__/code-gen/conditional.test.ts
@@ -13,10 +13,8 @@ describe("conditional", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(parsers).toEqual({
       input: "parser.ObjectLiteral()",
-      output: "ref_0",
-      deps: {
-        ref_0: 'parser.ObjectLiteral(["prop", false, parser.String])',
-      },
+      output: `parser.ObjectLiteral(["prop", false, parser.String])`,
+      deps: {},
     })
   })
   test("MyConditionalType<string>", () => {
@@ -30,10 +28,8 @@ describe("conditional", () => {
     `)
     expect(parsers).toEqual({
       input: "parser.ObjectLiteral()",
-      output: "ref_0",
-      deps: {
-        ref_0: 'parser.ObjectLiteral(["prop", false, parser.Number])',
-      },
+      output: `parser.ObjectLiteral(["prop", false, parser.Number])`,
+      deps: {},
     })
   })
   test("MyDeepConditionalType<number>", () => {
@@ -57,8 +53,7 @@ describe("conditional", () => {
       output: "ref_0",
       deps: {
         ref_0:
-          'parser.ObjectLiteral(["t", false, parser.Number], ["deep", false, ref_1])',
-        ref_1: 'parser.ObjectLiteral(["prop", false, parser.Number])',
+          'parser.ObjectLiteral(["t", false, parser.Number], ["deep", false, parser.ObjectLiteral(["prop", false, parser.Number])])',
       },
     })
   })
@@ -81,8 +76,8 @@ describe("conditional", () => {
       input: "parser.ObjectLiteral()",
       output: "ref_0",
       deps: {
-        ref_0: 'parser.ObjectLiteral(["deep", false, ref_1])',
-        ref_1: 'parser.ObjectLiteral(["prop", false, parser.String])',
+        ref_0:
+          'parser.ObjectLiteral(["deep", false, parser.ObjectLiteral(["prop", false, parser.String])])',
       },
     })
   })
@@ -105,7 +100,6 @@ describe("conditional", () => {
       },
     })
   })
-
   test("MyDeepConditionalRecursiveType<number>", () => {
     const parsers = generateParsersForFunction(`
       interface MyDeepConditionalRecursiveType<T> {
@@ -149,12 +143,9 @@ describe("conditional", () => {
 
     expect(parsers).toEqual({
       input: "parser.ObjectLiteral()",
-      output: "ref_1",
-      deps: {
-        ref_0: 'parser.ObjectLiteral(["h", false, parser.Number])',
-        ref_1:
-          'parser.ObjectLiteral(["prop", false, parser.String], ["x", false, ref_0])',
-      },
+      output:
+        'parser.ObjectLiteral(["prop", false, parser.String], ["x", false, parser.ObjectLiteral(["h", false, parser.Number])])',
+      deps: {},
     })
   })
 })

--- a/packages/core/src/generateParser/__tests__/code-gen/mapped.test.ts
+++ b/packages/core/src/generateParser/__tests__/code-gen/mapped.test.ts
@@ -164,11 +164,9 @@ describe("mapped", () => {
 
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(parsers).toEqual({
-      deps: {
-        MyMappedTypeParser: 'parser.StringLiteral("kaas")',
-      },
+      deps: {},
       input: "parser.ObjectLiteral()",
-      output: "MyMappedTypeParser",
+      output: `parser.StringLiteral("kaas")`,
     })
   })
   test("Pick", () => {

--- a/packages/core/src/generateParser/__tests__/code-gen/tuple.test.ts
+++ b/packages/core/src/generateParser/__tests__/code-gen/tuple.test.ts
@@ -259,10 +259,8 @@ describe("tuple", () => {
     // console.log(JSON.stringify(modelMap, null, 4))
     expect(parsers).toEqual({
       input: "parser.ObjectLiteral()",
-      output: `XParser`,
-      deps: {
-        XParser: `parser.Tuple([parser.Number], [parser.Number])`,
-      },
+      output: `parser.Tuple([parser.Number], [parser.Number])`,
+      deps: {},
     })
   })
 })


### PR DESCRIPTION
Maybe I was overthinking it. Inlining conditional types renders the best result after all.
It's very hard to get the type parameter right. To generate the correct parsers, it's actually not really necessary to generate it with all the details the data model has. The downside is that we might generate duplicate parser code. But it seems that this works more reliably.