### PR TITLE
Feature/implement type query

### DIFF
--- a/packages/core/src/generateManifest/generateManifest.ts
+++ b/packages/core/src/generateManifest/generateManifest.ts
@@ -78,7 +78,9 @@ function withExportModifier(ref: Model): Model {
   }
 
   const modifiersWithExport: ts.Modifier[] = [
-    ...(ref.modifiers ?? []),
+    ...(ref.modifiers ?? []).filter(
+      (m) => m.kind === ts.SyntaxKind.DeclareKeyword,
+    ),
     ts.factory.createModifier(ts.SyntaxKind.ExportKeyword),
   ]
 

--- a/packages/core/src/generateManifest/generateManifest.ts
+++ b/packages/core/src/generateManifest/generateManifest.ts
@@ -79,7 +79,7 @@ function withExportModifier(ref: Model): Model {
 
   const modifiersWithExport: ts.Modifier[] = [
     ...(ref.modifiers ?? []).filter(
-      (m) => m.kind === ts.SyntaxKind.DeclareKeyword,
+      (m) => m.kind !== ts.SyntaxKind.DeclareKeyword,
     ),
     ts.factory.createModifier(ts.SyntaxKind.ExportKeyword),
   ]

--- a/packages/core/src/generateModel/__tests__/typeQuery.test.ts
+++ b/packages/core/src/generateModel/__tests__/typeQuery.test.ts
@@ -1,0 +1,420 @@
+import { generateParserModelForReturnType } from "../../lib/tsTestUtils"
+
+describe("typeQuery", () => {
+  test(`typeof {} as const`, () => {
+    const modelMap = generateParserModelForReturnType(`
+      const myConst = {
+        a: [1, 2],
+        b: [3, 4],
+      } as const
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "Example",
+      },
+      deps: {
+        Example: {
+          type: "object",
+          members: [
+            {
+              type: "member",
+              name: "a",
+              optional: false,
+              parser: {
+                type: "tuple",
+                elements: [
+                  {
+                    type: "tupleElement",
+                    position: 0,
+                    parser: {
+                      type: "number-literal",
+                      literal: 1,
+                    },
+                  },
+                  {
+                    type: "tupleElement",
+                    position: 1,
+                    parser: {
+                      type: "number-literal",
+                      literal: 2,
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              type: "member",
+              name: "b",
+              optional: false,
+              parser: {
+                type: "tuple",
+                elements: [
+                  {
+                    type: "tupleElement",
+                    position: 0,
+                    parser: {
+                      type: "number-literal",
+                      literal: 3,
+                    },
+                  },
+                  {
+                    type: "tupleElement",
+                    position: 1,
+                    parser: {
+                      type: "number-literal",
+                      literal: 4,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+  test(`typeof {}`, () => {
+    const modelMap = generateParserModelForReturnType(`
+      const myConst = {
+        a: [1, 2],
+        b: [3, 4],
+      }
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "Example",
+      },
+      deps: {
+        Example: {
+          type: "object",
+          members: [
+            {
+              type: "member",
+              name: "a",
+              optional: false,
+              parser: {
+                type: "array",
+                element: {
+                  type: "arrayElement",
+                  parser: {
+                    type: "number",
+                  },
+                },
+              },
+            },
+            {
+              type: "member",
+              name: "b",
+              optional: false,
+              parser: {
+                type: "array",
+                element: {
+                  type: "arrayElement",
+                  parser: {
+                    type: "number",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+  test(`typeof [] as const`, () => {
+    const modelMap = generateParserModelForReturnType(`
+      const myConst = [
+        {
+          a: 123
+        },
+        {
+          b: 456,
+        }
+      ] as const
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "Example",
+      },
+      deps: {
+        Example: {
+          type: "tuple",
+          elements: [
+            {
+              type: "tupleElement",
+              position: 0,
+              parser: {
+                type: "object",
+                members: [
+                  {
+                    type: "member",
+                    name: "a",
+                    optional: false,
+                    parser: {
+                      type: "number-literal",
+                      literal: 123,
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              type: "tupleElement",
+              position: 1,
+              parser: {
+                type: "object",
+                members: [
+                  {
+                    type: "member",
+                    name: "b",
+                    optional: false,
+                    parser: {
+                      type: "number-literal",
+                      literal: 456,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+  test(`typeof []`, () => {
+    const modelMap = generateParserModelForReturnType(`
+      const myConst = [
+        {
+          a: 123
+        },
+        {
+          b: 456,
+        }
+      ]
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "Example",
+      },
+      deps: {
+        Example: {
+          type: "array",
+          element: {
+            type: "arrayElement",
+            parser: {
+              // TODO suboptimal, but okay for now
+              type: "union",
+              oneOf: [
+                {
+                  type: "object",
+                  members: [
+                    {
+                      type: "member",
+                      name: "a",
+                      optional: false,
+                      parser: {
+                        type: "number-literal",
+                        literal: 123,
+                      },
+                    },
+                    {
+                      type: "member",
+                      name: "b",
+                      optional: true,
+                      parser: {
+                        type: "number-literal",
+                        literal: 456,
+                      },
+                    },
+                  ],
+                },
+                {
+                  type: "object",
+                  members: [
+                    {
+                      type: "member",
+                      name: "b",
+                      optional: false,
+                      parser: {
+                        type: "number-literal",
+                        literal: 456,
+                      },
+                    },
+                    {
+                      type: "member",
+                      name: "a",
+                      optional: true,
+                      parser: {
+                        type: "number-literal",
+                        literal: 123,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    })
+  })
+  test(`typeof "str" as const`, () => {
+    const modelMap = generateParserModelForReturnType(`
+      const myConst = "str" as const
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "Example",
+      },
+      deps: {
+        Example: {
+          type: "string-literal",
+          literal: "str",
+        },
+      },
+    })
+  })
+  test(`typeof () => 123`, () => {
+    expect(() =>
+      generateParserModelForReturnType(`
+      const myConst = () => 123 as const
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `),
+    ).toThrowError("Can't make a parser for a function type")
+  })
+  test(`typeof enums`, () => {
+    const modelMap = generateParserModelForReturnType(`
+      enum Aad {
+        Aap = "aap",
+        Noot = "noot",
+      }
+
+      enum Abc {
+        A = "a",
+        B = "b",
+        C = "c",
+        D = "d",
+      }
+
+      const myConst = {
+        [Aad.Aap]: [
+          Abc.A,
+          Abc.B,
+        ],
+        [Aad.Noot]: [
+          Abc.C,
+          Abc.D,
+        ],
+      } as const
+
+      export type Example = typeof myConst
+
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(modelMap, null, 4))
+    expect(modelMap).toEqual({
+      root: {
+        type: "reference",
+        typeName: "Example",
+      },
+      deps: {
+        Example: {
+          type: "object",
+          members: [
+            {
+              type: "member",
+              name: "aap",
+              optional: false,
+              parser: {
+                type: "tuple",
+                elements: [
+                  {
+                    type: "tupleElement",
+                    position: 0,
+                    parser: {
+                      type: "string-literal",
+                      literal: "a",
+                    },
+                  },
+                  {
+                    type: "tupleElement",
+                    position: 1,
+                    parser: {
+                      type: "string-literal",
+                      literal: "b",
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              type: "member",
+              name: "noot",
+              optional: false,
+              parser: {
+                type: "tuple",
+                elements: [
+                  {
+                    type: "tupleElement",
+                    position: 0,
+                    parser: {
+                      type: "string-literal",
+                      literal: "c",
+                    },
+                  },
+                  {
+                    type: "tupleElement",
+                    position: 1,
+                    parser: {
+                      type: "string-literal",
+                      literal: "d",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+})

--- a/packages/core/src/generateModel/generateFromTypeNode/generateFromTypeNode.ts
+++ b/packages/core/src/generateModel/generateFromTypeNode/generateFromTypeNode.ts
@@ -212,6 +212,17 @@ export default function generateFromTypeNode(
     throw new PheroParseError("Function types are not supported", typeNode)
   }
 
+  if (ts.isTypeQueryNode(typeNode)) {
+    return generateFromType(
+      type,
+      typeNode,
+      location,
+      typeChecker,
+      deps,
+      typeParams,
+    )
+  }
+
   throw new PheroParseError(
     "TypeNode not implemented " + typeNode.kind,
     typeNode,

--- a/packages/core/src/generateParser/__tests__/code-gen/typeQuery.test.ts
+++ b/packages/core/src/generateParser/__tests__/code-gen/typeQuery.test.ts
@@ -1,0 +1,155 @@
+import { generateParsersForFunction } from "../../../lib/tsTestUtils"
+
+describe("typeQuery", () => {
+  test(`typeof {} as const`, () => {
+    const parsers = generateParsersForFunction(`
+      const myConst = {
+        a: [1, 2],
+        b: [3, 4],
+      } as const
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(parsers, null, 4))
+    expect(parsers).toEqual({
+      input: "parser.ObjectLiteral()",
+      output: "ExampleParser",
+      deps: {
+        ExampleParser:
+          'parser.ObjectLiteral(["a", false, parser.Tuple([parser.NumberLiteral(1)], [parser.NumberLiteral(2)])], ["b", false, parser.Tuple([parser.NumberLiteral(3)], [parser.NumberLiteral(4)])])',
+      },
+    })
+  })
+  test(`typeof {}`, () => {
+    const parsers = generateParsersForFunction(`
+      const myConst = {
+        a: [1, 2],
+        b: [3, 4],
+      }
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(parsers, null, 4))
+    expect(parsers).toEqual({
+      input: "parser.ObjectLiteral()",
+      output: "ExampleParser",
+      deps: {
+        ExampleParser:
+          'parser.ObjectLiteral(["a", false, parser.Array(parser.Number)], ["b", false, parser.Array(parser.Number)])',
+      },
+    })
+  })
+  test(`typeof [] as const`, () => {
+    const parsers = generateParsersForFunction(`
+      const myConst = [
+        {
+          a: 123
+        },
+        {
+          b: 456,
+        }
+      ] as const
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+
+    // console.log(JSON.stringify(parsers, null, 4))
+    expect(parsers).toEqual({
+      input: "parser.ObjectLiteral()",
+      output: "ExampleParser",
+      deps: {
+        ExampleParser:
+          'parser.Tuple([parser.ObjectLiteral(["a", false, parser.NumberLiteral(123)])], [parser.ObjectLiteral(["b", false, parser.NumberLiteral(456)])])',
+      },
+    })
+  })
+  test(`typeof []`, () => {
+    const parsers = generateParsersForFunction(`
+      const myConst = [
+        {
+          a: 123
+        },
+        {
+          b: 456,
+        }
+      ]
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+    // console.log(JSON.stringify(parsers, null, 4))
+    expect(parsers).toEqual({
+      input: "parser.ObjectLiteral()",
+      output: "ExampleParser",
+      deps: {
+        ExampleParser:
+          'parser.Array(parser.Union(parser.ObjectLiteral(["a", false, parser.NumberLiteral(123)], ["b", true, parser.NumberLiteral(456)]), parser.ObjectLiteral(["b", false, parser.NumberLiteral(456)], ["a", true, parser.NumberLiteral(123)])))',
+      },
+    })
+  })
+  test(`typeof "str" as const`, () => {
+    const parsers = generateParsersForFunction(`
+      const myConst = "str" as const
+      
+      type Example = typeof myConst
+      
+      function test(): Example { throw new Error() }
+    `)
+    // console.log(JSON.stringify(parsers, null, 4))
+    expect(parsers).toEqual({
+      input: "parser.ObjectLiteral()",
+      output: "ExampleParser",
+      deps: {
+        ExampleParser: 'parser.StringLiteral("str")',
+      },
+    })
+  })
+  test(`typeof enums`, () => {
+    const parsers = generateParsersForFunction(`
+      enum Aad {
+        Aap = "aap",
+        Noot = "noot",
+      }
+
+      enum Abc {
+        A = "a",
+        B = "b",
+        C = "c",
+        D = "d",
+      }
+
+      const myConst = {
+        [Aad.Aap]: [
+          Abc.A,
+          Abc.B,
+        ],
+        [Aad.Noot]: [
+          Abc.C,
+          Abc.D,
+        ],
+      } as const
+
+      export type Example = typeof myConst
+
+      function test(): Example { throw new Error() }
+    `)
+    // console.log(JSON.stringify(parsers, null, 4))
+    expect(parsers).toEqual({
+      input: "parser.ObjectLiteral()",
+      output: "ExampleParser",
+      deps: {
+        ExampleParser:
+          'parser.ObjectLiteral(["aap", false, parser.Tuple([parser.StringLiteral("a")], [parser.StringLiteral("b")])], ["noot", false, parser.Tuple([parser.StringLiteral("c")], [parser.StringLiteral("d")])])',
+      },
+    })
+  })
+})

--- a/packages/core/src/lib/tsUtils.ts
+++ b/packages/core/src/lib/tsUtils.ts
@@ -237,7 +237,8 @@ export function isExternal(node: ts.Declaration, prog: ts.Program): boolean {
 }
 
 export function isLib(node: ts.Declaration, prog: ts.Program): boolean {
-  return prog.isSourceFileDefaultLibrary(node.getSourceFile())
+  const sf = node.getSourceFile()
+  return !!sf && prog.isSourceFileDefaultLibrary(sf)
 }
 
 export function getNameAsString(

--- a/packages/core/src/parsePheroApp/parseModels.ts
+++ b/packages/core/src/parsePheroApp/parseModels.ts
@@ -1,4 +1,5 @@
 import ts from "typescript"
+import { tsx } from ".."
 import { PheroParseError } from "../domain/errors"
 import {
   type Model,
@@ -123,5 +124,79 @@ function getDeclaration(
     throw new PheroParseError("Entity must have declaration", typeNode)
   }
 
-  return { symbol, declaration }
+  return {
+    symbol,
+    declaration: handleTypeQueryDeclaration(declaration, typeChecker),
+  }
+}
+
+function handleTypeQueryDeclaration(
+  declr: ts.Declaration,
+  typeChecker: ts.TypeChecker,
+): ts.Declaration {
+  if (
+    !ts.isTypeAliasDeclaration(declr) ||
+    !declr.type ||
+    !ts.isTypeQueryNode(declr.type)
+  ) {
+    return declr
+  }
+
+  return tsx.typeAlias({
+    name: declr.name,
+    typeParameters: declr.typeParameters?.map((p) => p),
+    type: createTypeQueryType(declr.type.exprName, typeChecker),
+  })
+}
+
+function createTypeQueryType(
+  expr: ts.EntityName,
+  typeChecker: ts.TypeChecker,
+): ts.TypeNode {
+  return loop(expr)
+  function loop(n: ts.Node): ts.TypeNode {
+    if (ts.isLiteralExpression(n)) {
+      return ts.factory.createLiteralTypeNode(n)
+    }
+    if (ts.isObjectLiteralExpression(n)) {
+      return ts.factory.createTypeLiteralNode(
+        n.properties.map((p) => {
+          if (!ts.isPropertyAssignment(p)) {
+            // TODO:
+            // ShorthandPropertyAssignment
+            // SpreadAssignment
+            // GetAccessorDeclaration
+            throw new PheroParseError(
+              "We only support property assignments for now",
+              p,
+            )
+          }
+
+          return ts.factory.createPropertySignature(
+            ts.canHaveModifiers(p) ? ts.getModifiers(p) : undefined,
+            p.name,
+            undefined,
+            typeChecker.typeToTypeNode(
+              typeChecker.getTypeAtLocation(p.initializer),
+              undefined,
+              undefined,
+            ),
+          )
+        }),
+      )
+    }
+
+    const symbol = typeChecker.getSymbolAtLocation(expr)
+    const declr = symbol?.declarations?.[0]
+
+    if (declr && ts.isVariableDeclaration(declr) && declr?.initializer) {
+      return loop(declr.initializer)
+    }
+
+    throw new Error(
+      `Cant find declraration for EnityName ${
+        ts.isIdentifier(expr) ? expr.text : expr.right.text
+      }.`,
+    )
+  }
 }


### PR DESCRIPTION
implements type query nodes:

```
const myConst = { 
  aap: 123,
  noot: 456,
} as const

type MyConst = typeof myConst
```

Will generate a parser that matches on the literal defined structure of `myConst`. If it hadn't the "as const" expression, it would generate a parser with just string properties, exactly like the typescript compiler.