### PR TITLE
Hotfix/various fixes for client

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,5 @@
     "packages/dev",
     "packages/cli"
   ],
-  "version": "0.10.0-alpha.4"
+  "version": "0.10.0-alpha.5"
 }

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phero/client",
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@phero/client",
-      "version": "0.10.0-alpha.4",
+      "version": "0.10.0-alpha.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@phero/core": "^0.10.0-alpha.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phero/client",
-  "version": "0.10.0-alpha.4",
+  "version": "0.10.0-alpha.5",
   "main": "dist/index.js",
   "description": "Client library for Phero",
   "homepage": "https://phero.dev",

--- a/packages/client/src/code-gen/generateClientSource.ts
+++ b/packages/client/src/code-gen/generateClientSource.ts
@@ -103,7 +103,7 @@ export default function generateClientSource(
         generateParserFunction(
           `${service.name}__${func.name}__parser`,
           func.returnTypeModel,
-          func.returnType,
+          cloneTS(func.returnType),
           depRef,
         ),
       ),

--- a/packages/client/src/code-gen/generateClientSource.ts
+++ b/packages/client/src/code-gen/generateClientSource.ts
@@ -187,13 +187,19 @@ function generateError(parsedError: PheroError): ts.ClassDeclaration {
     elements: [
       tsx.constructor({
         params: parsedError.properties.map((prop) =>
-          tsx.param({
-            public: true,
-            readonly: true,
-            name: prop.name,
-            type: cloneTS(prop.type),
-            questionToken: prop.optional,
-          }),
+          prop.name === "message"
+            ? tsx.param({
+                name: prop.name,
+                type: cloneTS(prop.type),
+                questionToken: prop.optional,
+              })
+            : tsx.param({
+                public: true,
+                readonly: true,
+                name: prop.name,
+                type: cloneTS(prop.type),
+                questionToken: prop.optional,
+              }),
         ),
         block: tsx.block(
           tsx.statement.expression(


### PR DESCRIPTION
2 small fixes:
* fixes regression on generated Error classes, message prop should not have a public+readonly modifier
* cloning of literal type nodes went wrong on the generated client