### PR TITLE
Fix errors from exported servers failing to parse

### DIFF
--- a/packages/client/src/package/BasePheroClient.ts
+++ b/packages/client/src/package/BasePheroClient.ts
@@ -59,7 +59,20 @@ export class BasePheroClient {
           `Result of RPC ${serviceName}.${functionName} has incorrect output.`,
         )
       } else {
-        throw errorParser(data)
+        const isValidError =
+          typeof data === "object" &&
+          data !== null &&
+          "error" in data &&
+          typeof data.error === "object" &&
+          data.error !== null
+
+        if (!isValidError) {
+          throw new Error(
+            `Error response of RPC ${serviceName}.${functionName} is invalid.`,
+          )
+        }
+
+        throw errorParser(data.error)
       }
     }
 

--- a/packages/server/src/commands/serve/DevServer.ts
+++ b/packages/server/src/commands/serve/DevServer.ts
@@ -211,7 +211,7 @@ export default class DevServer {
               })
             } else if (rpcResult.status === 400) {
               // Validation error(s)
-              res.write(JSON.stringify(rpcResult.errors, null, 4))
+              res.write(JSON.stringify({ errors: rpcResult.errors }, null, 4))
               this.eventEmitter.emit({
                 type: "RPC_FAILED_VALIDATION_ERROR",
                 url: req.url,
@@ -229,7 +229,7 @@ export default class DevServer {
               })
             } else if (rpcResult.status === 500) {
               // Error is thrown
-              res.write(JSON.stringify(rpcResult.error))
+              res.write(JSON.stringify({ error: rpcResult.error }))
               this.eventEmitter.emit({
                 type: "RPC_FAILED_FUNCTION_ERROR",
                 url: req.url,


### PR DESCRIPTION
It used to be that errors returned by exported servers wouldn't be parsed by the phero client, as they returned errors in a different format from the dev server.

This commit fixes that by making dev servers and exported servers use the same format.