### PR TITLE
fix undefined response resulting in JSON syntax error

### DIFF
--- a/packages/client/src/package/BasePheroClient.ts
+++ b/packages/client/src/package/BasePheroClient.ts
@@ -51,14 +51,14 @@ export class BasePheroClient {
       throw new NetworkError()
     }
 
-    const data = await result.json()
-
     if (!result.ok) {
       if (result.status === 400) {
         throw new Error(
           `Result of RPC ${serviceName}.${functionName} has incorrect output.`,
         )
       } else {
+        const data = await result.json()
+
         const isValidError =
           typeof data === "object" &&
           data !== null &&
@@ -74,6 +74,11 @@ export class BasePheroClient {
 
         throw errorParser(data.error)
       }
+    }
+
+    let data = undefined
+    if (result.status !== 204) {
+      data = await result.json()
     }
 
     const parseResult = resultParser(data)

--- a/packages/core/src/domain/RPCResult.ts
+++ b/packages/core/src/domain/RPCResult.ts
@@ -2,12 +2,17 @@ import { type DataParseError } from "./Parser"
 
 export type RPCResult<T> =
   | RPCOkResult<T>
+  | RPCNoContentResult
   | RPCBadRequestResult
   | RPCInternalServerErrorResult
 
 export interface RPCOkResult<T> {
   status: 200
   result: T
+}
+
+export interface RPCNoContentResult {
+  status: 204
 }
 
 export interface RPCBadRequestResult {

--- a/packages/server/src/code-gen/generatePheroExecutionFile.ts
+++ b/packages/server/src/code-gen/generatePheroExecutionFile.ts
@@ -237,6 +237,19 @@ function generateRPCExecutor(
           ),
         }),
 
+        tsx.statement.if({
+          expression: tsx.expression.binary(
+            tsx.expression.identifier("result"),
+            "===",
+            tsx.literal.undefined,
+          ),
+          then: tsx.statement.return(
+            tsx.literal.object(
+              tsx.property.assignment("status", tsx.literal.number(204)),
+            ),
+          ),
+        }),
+
         tsx.statement.return(
           tsx.literal.object(
             tsx.property.assignment("status", tsx.literal.number(200)),

--- a/packages/server/src/commands/export/gcloud-functions/generateLibFile.ts
+++ b/packages/server/src/commands/export/gcloud-functions/generateLibFile.ts
@@ -46,6 +46,9 @@ export async function writeResponse(
         case 200:
             res.end(JSON.stringify(response.result));
             break;
+        case 204:
+            res.end();
+            break;
         case 400:
             res.end(JSON.stringify({ errors: response.errors }));
             break;

--- a/packages/server/src/commands/export/nodejs/generateLibFile.ts
+++ b/packages/server/src/commands/export/nodejs/generateLibFile.ts
@@ -58,6 +58,9 @@ export async function writeResponse(
         case 200:
             res.end(JSON.stringify(response.result));
             break;
+        case 204:
+            res.end();
+            break;
         case 400:
             res.end(JSON.stringify({ errors: response.errors }));
             break;

--- a/packages/server/src/commands/export/vercel/generateLibFile.ts
+++ b/packages/server/src/commands/export/vercel/generateLibFile.ts
@@ -46,6 +46,9 @@ export async function writeResponse(
         case 200:
             res.end(JSON.stringify(response.result));
             break;
+        case 204:
+            res.end();
+            break;
         case 400:
             res.end(JSON.stringify({ errors: response.errors }));
             break;

--- a/packages/server/src/commands/serve/DevServer.ts
+++ b/packages/server/src/commands/serve/DevServer.ts
@@ -196,10 +196,8 @@ export default class DevServer {
 
             res.statusCode = rpcResult.status
 
-            if (rpcResult.status === 200) {
-              if (rpcResult.result === undefined) {
-                res.statusCode = 204
-              } else {
+            if (rpcResult.status === 200 || rpcResult.status === 204) {
+              if (rpcResult.status !== 204) {
                 res.write(JSON.stringify(rpcResult.result))
               }
               this.eventEmitter.emit({


### PR DESCRIPTION
The following example RPC

    export async function test(): Promise<undefined> {
        return undefined
    }

will always trigger the following error on the client when called:

    Uncaught (in promise) SyntaxError: JSON.parse: unexpected end of data at line 1 column 1 of the JSON data

The issue is the incomplete handling of 'undefined' responses. For the DevServer we convert undefined responses to 204 No Content responses, while the client doesn't know how to deal with these. The export servers don't know how to deal with 'undefined' responses either, and try to serialize them anyway.

Fix this by making the client understand 204 No Content responses, and by making the export servers also be able to generate 204 No Content responses.