### PR TITLE
remove TypeScript from client bundle

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,4 @@
-export { parser, Parser, ParseResult } from "@phero/core"
+export { parser, Parser, ParseResult } from "@phero/core/runtime"
 
 export {
   PheroRequest,

--- a/packages/client/src/package/BasePheroClient.ts
+++ b/packages/client/src/package/BasePheroClient.ts
@@ -1,4 +1,4 @@
-import type { ParseResult, DataParseError } from "@phero/core"
+import type { ParseResult, DataParseError } from "@phero/core/runtime"
 
 export interface PheroRequest {
   method: "GET" | "POST"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@phero/core",
   "version": "0.10.6",
-  "main": "dist/index.js",
   "homepage": "https://phero.dev",
   "repository": "phero-hq/phero",
   "bugs": "https://github.com/phero-hq/phero/issues",
@@ -10,6 +9,16 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./runtime": "./dist/runtime.js"
+  },
+  "typesVersions": {
+    "*": {
+      "index": ["./dist/index.d.ts"],
+      "runtime": ["./dist/runtime.d.ts"]
+    }
   },
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,12 +12,6 @@ export {
   PortInUseError,
   hasErrorCode,
 } from "./domain/errors"
-export type {
-  RPCResult,
-  RPCOkResult,
-  RPCBadRequestResult,
-  RPCInternalServerErrorResult,
-} from "./domain/RPCResult"
 
 export { parsePheroApp } from "./parsePheroApp"
 export { default as parseManifest } from "./parseManifest/parseManifest"
@@ -37,12 +31,3 @@ export {
 
 export { VirtualCompilerHost } from "./lib/VirtualCompilerHost"
 export { default as cloneTS } from "./lib/cloneTS"
-
-export * as parser from "./generateParser/static"
-export type {
-  Parser,
-  ParseResult,
-  DataParseSuccess,
-  DataParseFailure,
-  DataParseError,
-} from "./domain/Parser"

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,0 +1,16 @@
+export * as parser from "./generateParser/static"
+
+export type {
+  Parser,
+  ParseResult,
+  DataParseSuccess,
+  DataParseFailure,
+  DataParseError,
+} from "./domain/Parser"
+
+export type {
+  RPCResult,
+  RPCOkResult,
+  RPCBadRequestResult,
+  RPCInternalServerErrorResult,
+} from "./domain/RPCResult"

--- a/packages/server/src/commands/serve/DevServer.ts
+++ b/packages/server/src/commands/serve/DevServer.ts
@@ -4,8 +4,8 @@ import {
   PheroApp,
   parsePheroApp,
   PortInUseError,
-  RPCResult,
 } from "@phero/core"
+import { RPCResult } from "@phero/core/runtime"
 import { ServerCommandServe, ServerDevEventEmitter } from "@phero/dev"
 import crypto from "crypto"
 import { promises as fs } from "fs"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,7 @@ export {
   ParseResult,
   RPCResult,
   DataParseError,
-} from "@phero/core"
+} from "@phero/core/runtime"
 
 export type PheroServiceFunctions = Record<string, Function>
 


### PR DESCRIPTION
Due to the structure of our import paths, TypeScript itself is getting bundled with our client code, despite us not using it at runtime. This is because @phero/core also exports the code generation functions, which do depend on TypeScript. Fix this by introducing @phero/core/runtime, which can be safely imported by @phero/client without also pulling down TypeScript.

This reduces the bundle size by 3.6 MB (gzip: 1.0 MB), leaving us with a
bundle size of 16 kB (gzip: 3 kB).