### PR TITLE
cli: fix tests

### DIFF
--- a/packages/dev/src/cli/__snapshots__/commands.test.ts.snap
+++ b/packages/dev/src/cli/__snapshots__/commands.test.ts.snap
@@ -287,6 +287,38 @@ Object {
 }
 `;
 
+exports[`parseServerCommand export cmd:   'phero-server export --flavor gcloud-functions' 1`] = `
+Object {
+  "flavor": "gcloud-functions",
+  "name": "export",
+  "verbose": false,
+}
+`;
+
+exports[`parseServerCommand export cmd:   'phero-server export --flavor nodejs --verbose' 1`] = `
+Object {
+  "flavor": "nodejs",
+  "name": "export",
+  "verbose": true,
+}
+`;
+
+exports[`parseServerCommand export cmd:   'phero-server export --flavor nodejs' 1`] = `
+Object {
+  "flavor": "nodejs",
+  "name": "export",
+  "verbose": false,
+}
+`;
+
+exports[`parseServerCommand export cmd:   'phero-server export --flavor vercel' 1`] = `
+Object {
+  "flavor": "vercel",
+  "name": "export",
+  "verbose": false,
+}
+`;
+
 exports[`parseServerCommand export cmd:   'phero-server export --help' 1`] = `
 Object {
   "command": "export",
@@ -294,24 +326,10 @@ Object {
 }
 `;
 
-exports[`parseServerCommand export cmd:   'phero-server export --verbose' 1`] = `
-Object {
-  "name": "export",
-  "verbose": true,
-}
-`;
-
 exports[`parseServerCommand export cmd:   'phero-server export -h' 1`] = `
 Object {
   "command": "export",
   "name": "help",
-}
-`;
-
-exports[`parseServerCommand export cmd:   'phero-server export' 1`] = `
-Object {
-  "name": "export",
-  "verbose": false,
 }
 `;
 

--- a/packages/dev/src/cli/commands.test.ts
+++ b/packages/dev/src/cli/commands.test.ts
@@ -92,12 +92,24 @@ describe("parseServerCommand", () => {
       expect(run("phero-server export -h")).toMatchSnapshot()
     })
 
-    test("cmd:   'phero-server export'", () => {
-      expect(run("phero-server export")).toMatchSnapshot()
+    test("cmd:   'phero-server export --flavor nodejs'", () => {
+      expect(run("phero-server export --flavor nodejs")).toMatchSnapshot()
     })
 
-    test("cmd:   'phero-server export --verbose'", () => {
-      expect(run("phero-server export --verbose")).toMatchSnapshot()
+    test("cmd:   'phero-server export --flavor gcloud-functions'", () => {
+      expect(
+        run("phero-server export --flavor gcloud-functions"),
+      ).toMatchSnapshot()
+    })
+
+    test("cmd:   'phero-server export --flavor vercel'", () => {
+      expect(run("phero-server export --flavor vercel")).toMatchSnapshot()
+    })
+
+    test("cmd:   'phero-server export --flavor nodejs --verbose'", () => {
+      expect(
+        run("phero-server export --flavor nodejs --verbose"),
+      ).toMatchSnapshot()
     })
   })
 })


### PR DESCRIPTION
The tests were never updated for the --flavor flag introduced in 1801a59 (implements export for nodejs and gcloud functions, moved to server, 2022-10-27).