### PR TITLE
Implements PheroUnchecked

### DIFF
--- a/packages/core/src/domain/ParserModel.ts
+++ b/packages/core/src/domain/ParserModel.ts
@@ -27,6 +27,7 @@ export enum ParserModelType {
   BigIntLiteral = "bigint-literal",
   Generic = "generic",
   TemplateLiteral = "template-literal",
+  Unchecked = "unchecked",
 }
 
 export type ParserModel =
@@ -56,6 +57,7 @@ export type ParserModel =
   | BigIntLiteralParserModel
   | GenericParserModel
   | TemplateLiteralParserModel
+  | UncheckedParserModel
 
 export interface StringParserModel {
   type: ParserModelType.String
@@ -166,4 +168,8 @@ export interface BigIntParserModel {
 export interface BigIntLiteralParserModel {
   type: ParserModelType.BigIntLiteral
   literal: ts.PseudoBigInt
+}
+
+export interface UncheckedParserModel {
+  type: ParserModelType.Unchecked
 }

--- a/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
+++ b/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
@@ -261,12 +261,18 @@ function generateFromDeclarationWithDeclaration(
   if (ts.isImportSpecifier(declaration)) {
     const symbol = typeChecker.getSymbolAtLocation(declaration.name)
     if (!symbol) {
-      throw new PheroParseError("HUWEWE 1", declaration)
+      throw new PheroParseError(
+        "No symbol found (generateFromDeclaration)",
+        declaration,
+      )
     }
 
     const aliasSymbol = typeChecker.getAliasedSymbol(symbol)
     if (!aliasSymbol.declarations?.[0]) {
-      throw new PheroParseError("HUWEWE 2", declaration)
+      throw new PheroParseError(
+        "No declaration found (generateFromDeclaration)",
+        declaration,
+      )
     }
 
     return generateFromDeclarationWithDeclaration(

--- a/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
+++ b/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
@@ -187,6 +187,17 @@ function generateFromDeclarationWithDeclaration(
   }
 
   if (ts.isTypeAliasDeclaration(declaration)) {
+    if (isPheroUncheckedReference(typeNode)) {
+      if (!isPheroUncheckedAllowed(typeNode)) {
+        throw new PheroParseError(
+          "PheroUnchecked is only allowed within PheroContext and PheroNextFunction, like this: PheroContext<{ dbClient: PheroUnchecked<MyDBClient> }>",
+          typeNode,
+        )
+      }
+
+      return { root: { type: ParserModelType.Unchecked }, deps }
+    }
+
     if (isEventuallyConditionalTypeNode(typeNode, typeChecker)) {
       return generateFromType(
         type,
@@ -499,4 +510,29 @@ function isEventuallyConditionalTypeNode(
   }
 
   return false
+}
+
+function isPheroUncheckedReference(typeNode: ts.TypeNode): boolean {
+  return (
+    ts.isTypeReferenceNode(typeNode) &&
+    ts.isIdentifier(typeNode.typeName) &&
+    typeNode.typeName.text === "PheroUnchecked"
+  )
+}
+
+function isPheroUncheckedAllowed(node: ts.Node): boolean {
+  if (ts.isSourceFile(node)) {
+    return false
+  }
+
+  if (
+    ts.isParameter(node.parent) &&
+    ts.isTypeReferenceNode(node) &&
+    ts.isIdentifier(node.typeName) &&
+    ["PheroContext", "PheroNextFunction"].includes(node.typeName.text)
+  ) {
+    return true
+  }
+
+  return isPheroUncheckedAllowed(node.parent)
 }

--- a/packages/core/src/generateModel/generateFromType.ts
+++ b/packages/core/src/generateModel/generateFromType.ts
@@ -6,11 +6,6 @@ import {
 } from "."
 import { PheroParseError } from "../domain/errors"
 import {
-  getObjectFlags,
-  getSymbolFlags,
-  getTypeFlags,
-} from "./generateParserModelUtils"
-import {
   type IndexMemberParserModel,
   type MemberParserModel,
   type ParserModel,
@@ -18,6 +13,7 @@ import {
   type TupleElementParserModel,
 } from "../domain/ParserModel"
 import generateFromTypeNode from "./generateFromTypeNode"
+import { getTypeFlags } from "./generateParserModelUtils"
 
 export default function generateFromType(
   type: ts.Type,

--- a/packages/core/src/generateParser/index.ts
+++ b/packages/core/src/generateParser/index.ts
@@ -168,6 +168,7 @@ function generateParserRef(
 ): ParserFuncRef {
   switch (model.type) {
     case ParserModelType.Any:
+    case ParserModelType.Unchecked:
       return tsx.expression.identifier("parser.Any")
     case ParserModelType.String:
       return tsx.expression.identifier("parser.String")
@@ -338,6 +339,7 @@ function generateRegExpSegmentForParser(parser: ParserModel): string {
     case ParserModelType.Tuple:
     case ParserModelType.TupleElement:
     case ParserModelType.Date:
+    case ParserModelType.Unchecked:
       throw new Error("Template literal segment is not supported")
   }
 }

--- a/packages/core/src/parsePheroApp/__tests__/parsePheroApp-middleware.test.ts
+++ b/packages/core/src/parsePheroApp/__tests__/parsePheroApp-middleware.test.ts
@@ -269,7 +269,7 @@ describe("parsePheroApp middleware", () => {
     )
   })
 
-  test.only("PheroUnchecked can't be used for service context", () => {
+  test("PheroUnchecked can't be used for service context", () => {
     expect(() =>
       parseProgram(
         createTestProgram(`

--- a/packages/core/src/parsePheroApp/__tests__/parsePheroApp-middleware.test.ts
+++ b/packages/core/src/parsePheroApp/__tests__/parsePheroApp-middleware.test.ts
@@ -36,7 +36,7 @@ describe("parsePheroApp middleware", () => {
           return "ok"
         }
 
-        async function myMiddleware(context: PheroContext, next: PheroNextFunction<{ x: number }) {
+        async function myMiddleware(context: PheroContext, next: PheroNextFunction<{ x: number }>) {
           await next({ x: 123 })
         }
 
@@ -65,5 +65,243 @@ describe("parsePheroApp middleware", () => {
       parsedApp.services[0].funcs[0].ref,
       "getArticle",
     )
+  })
+
+  test("should ignore members tagged with PheroUnchecked when parsing", () => {
+    const parsedApp = parseProgram(
+      createTestProgram(`
+        type PheroNextFunction<T = void> = T extends void
+          ? () => Promise<void>
+          : (ctx: T) => Promise<void>
+
+        type PheroContext<T = {}> = T
+
+        type PheroUnchecked<T> = T
+
+        class RealDB {
+          async query(): Promise<string> {
+            return "result"
+          }
+        }
+        
+        async function getArticle(ctx: PheroContext<{ db: PheroUnchecked<RealDB> }>): Promise<string> {
+          return ctx.db.query()
+        }
+
+        async function myMiddleware(context: PheroContext, next: PheroNextFunction<{ db: PheroUnchecked<RealDB> }>) {
+          await next({ db: new RealDB() })
+        }        
+
+        export const articleService = createService({
+          getArticle,
+        }, {
+          middleware: [myMiddleware]
+        })
+      `),
+    )
+
+    expect(parsedApp.services[0].config.contextTypeModel).toBeUndefined()
+
+    expect(parsedApp).toMatchObject({
+      services: [
+        expect.objectContaining({
+          name: "articleService",
+          funcs: [
+            expect.objectContaining({
+              name: "getArticle",
+              contextTypeModel: {
+                type: "object",
+                members: [
+                  {
+                    type: "member",
+                    name: "db",
+                    optional: false,
+                    parser: { type: "unchecked" },
+                  },
+                ],
+              },
+            }),
+          ],
+          config: expect.objectContaining({
+            middleware: [
+              expect.objectContaining({
+                nextTypeModel: {
+                  type: "object",
+                  members: [
+                    {
+                      type: "member",
+                      name: "db",
+                      optional: false,
+                      parser: { type: "unchecked" },
+                    },
+                  ],
+                },
+              }),
+            ],
+          }),
+        }),
+      ],
+    })
+
+    expectFunctionDeclarationWithName(
+      parsedApp.services[0].funcs[0].ref,
+      "getArticle",
+    )
+  })
+
+  test("PheroUnchecked shouldn't be used as input parameter", () => {
+    expect(() =>
+      parseProgram(
+        createTestProgram(`
+        type PheroNextFunction<T = void> = T extends void
+          ? () => Promise<void>
+          : (ctx: T) => Promise<void>
+
+        type PheroContext<T = {}> = T
+
+        type PheroUnchecked<T> = T
+
+        async function getArticle(test: PheroUnchecked<string>): Promise<string> {
+          return test
+        }
+
+        export const articleService = createService({
+          getArticle,
+        }, {
+          middleware: []
+        })
+      `),
+      ),
+    ).toThrow(
+      "PheroUnchecked is only allowed within PheroContext and PheroNextFunction, like this: PheroContext<{ dbClient: PheroUnchecked<MyDBClient> }>",
+    )
+  })
+
+  test("PheroUnchecked shouldn't be used as output result", () => {
+    expect(() =>
+      parseProgram(
+        createTestProgram(`
+        type PheroNextFunction<T = void> = T extends void
+          ? () => Promise<void>
+          : (ctx: T) => Promise<void>
+
+        type PheroContext<T = {}> = T
+
+        type PheroUnchecked<T> = T
+
+        async function getArticle(test: string): Promise<PheroUnchecked<string>> {
+          return test
+        }
+
+        export const articleService = createService({
+          getArticle,
+        }, {
+          middleware: []
+        })
+      `),
+      ),
+    ).toThrow(
+      "PheroUnchecked is only allowed within PheroContext and PheroNextFunction, like this: PheroContext<{ dbClient: PheroUnchecked<MyDBClient> }>",
+    )
+  })
+
+  test("PheroUnchecked shouldn't be used inside a parameter model", () => {
+    expect(() =>
+      parseProgram(
+        createTestProgram(`
+        type PheroNextFunction<T = void> = T extends void
+          ? () => Promise<void>
+          : (ctx: T) => Promise<void>
+
+        type PheroContext<T = {}> = T
+
+        type PheroUnchecked<T> = T
+
+        interface Result {
+          prop: PheroUnchecked<string>
+        }
+
+        async function getArticle(test: Result): Promise<string> {
+          return test.prop
+        }
+
+        export const articleService = createService({
+          getArticle,
+        }, {
+          middleware: []
+        })
+      `),
+      ),
+    ).toThrow(
+      "PheroUnchecked is only allowed within PheroContext and PheroNextFunction, like this: PheroContext<{ dbClient: PheroUnchecked<MyDBClient> }>",
+    )
+  })
+
+  test("PheroUnchecked shouldn't be used inside a result model", () => {
+    expect(() =>
+      parseProgram(
+        createTestProgram(`
+        type PheroNextFunction<T = void> = T extends void
+          ? () => Promise<void>
+          : (ctx: T) => Promise<void>
+
+        type PheroContext<T = {}> = T
+
+        type PheroUnchecked<T> = T
+
+        interface Result {
+          prop: PheroUnchecked<string>
+        }
+
+        async function getArticle(test: string): Promise<Result> {
+          return { prop: test }
+        }
+
+        export const articleService = createService({
+          getArticle,
+        }, {
+          middleware: []
+        })
+      `),
+      ),
+    ).toThrow(
+      "PheroUnchecked is only allowed within PheroContext and PheroNextFunction, like this: PheroContext<{ dbClient: PheroUnchecked<MyDBClient> }>",
+    )
+  })
+
+  test.only("PheroUnchecked can't be used for service context", () => {
+    expect(() =>
+      parseProgram(
+        createTestProgram(`
+        type PheroNextFunction<T = void> = T extends void
+          ? () => Promise<void>
+          : (ctx: T) => Promise<void>
+
+        type PheroContext<T = {}> = T
+
+        type PheroUnchecked<T> = T
+
+        class RealDB {
+          async query(): Promise<string> {
+            return "result"
+          }
+        }
+        
+        async function getArticle(ctx: PheroContext<{ result: string }>): Promise<string> {
+          return ctx.db.query()
+        }
+
+        async function myMiddleware(context: PheroContext<{ db: PheroUnchecked<RealDB> }>, next: PheroNextFunction<{ result: string }>) {
+          await next({ result: context.db.query() })
+        }
+
+        export const articleService = createService({
+          getArticle,
+        }, {
+          middleware: [myMiddleware]
+        })
+      `),
+      ),
+    ).toThrow("PheroUnchecked can't be service context")
   })
 })

--- a/packages/core/src/parsePheroApp/parseServiceContextType.ts
+++ b/packages/core/src/parsePheroApp/parseServiceContextType.ts
@@ -13,6 +13,7 @@ import {
 } from "../domain/PheroApp"
 import { DependencyMap } from "../generateModel"
 import { getNameAsString } from "../lib/tsUtils"
+import assert from "assert"
 
 export interface ServiceContext {
   properties: ContextProperty[]
@@ -101,7 +102,7 @@ function calculateServiceContext(
             containsPheroUnchecked(contextTypeModelMember, contextType, deps)
           ) {
             throw new PheroParseError(
-              "PheroUnchecked can't be service context",
+              "Contexts containing PheroUnchecked must be provided by a middleware",
               contextType,
             )
           }
@@ -226,19 +227,28 @@ function containsPheroUnchecked(
     case ParserModelType.Reference:
     case ParserModelType.Generic: {
       const parser = deps.get(parserModel.typeName)
-      if (!parser) {
-        throw new PheroParseError(
-          `Can't find parser with name ${parserModel.typeName}`,
-          contextType,
-        )
-      }
+      assert(parser, `Can't find parser with name ${parserModel.typeName}`)
       return containsPheroUnchecked(parser, contextType, deps)
     }
 
     case ParserModelType.Unchecked:
       return true
 
-    default:
+    case ParserModelType.String:
+    case ParserModelType.StringLiteral:
+    case ParserModelType.Number:
+    case ParserModelType.NumberLiteral:
+    case ParserModelType.Boolean:
+    case ParserModelType.BooleanLiteral:
+    case ParserModelType.Null:
+    case ParserModelType.Undefined:
+    case ParserModelType.Enum:
+    case ParserModelType.EnumMember:
+    case ParserModelType.Date:
+    case ParserModelType.Any:
+    case ParserModelType.BigInt:
+    case ParserModelType.BigIntLiteral:
+    case ParserModelType.TemplateLiteral:
       return false
   }
 }

--- a/packages/core/src/parsePheroApp/parseServiceDefinition.ts
+++ b/packages/core/src/parsePheroApp/parseServiceDefinition.ts
@@ -51,6 +51,7 @@ export default function parseServiceDefinition(
   const serviceContextConfig = parseServiceContextType(
     serviceConfig,
     pheroFunctions,
+    deps,
   )
 
   return {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,8 @@ export interface PheroServiceDefinition {
 
 export type PheroContext<T = {}> = T
 
+export type PheroUnchecked<T> = T
+
 export type PheroNextFunction<T = void> = T extends void
   ? () => Promise<void>
   : (ctx: T) => Promise<void>

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,21 @@ export interface PheroServiceDefinition {
 
 export type PheroContext<T = {}> = T
 
+/**
+ * By default all middleware input is parsed by Phero. With PheroUnchecked<T> you can
+ * mark a property within your middleware context, so that Phero will skip it during
+ * the parsing step. E.g.
+ * @example
+ * ```typescript
+ *   async function getArticle(ctx: PheroContext<{ db: PheroUnchecked<RealDB> }>): Promise<string> {
+ *     return ctx.db.query()
+ *   }
+ *
+ *   async function myMiddleware(context: PheroContext, next: PheroNextFunction<{ db: PheroUnchecked<DBClient> }>) {
+ *     await next({ db: new DBClient() })
+ *   }
+ * ```
+ */
 export type PheroUnchecked<T> = T
 
 export type PheroNextFunction<T = void> = T extends void


### PR DESCRIPTION
With the PheroUnchecked utility type, a user can tag a context member to denote that Phero should skip validation for input/output of the middleware/function.

Last 2 commits are random improvements to the codebase