### PR TITLE
fix ts.Node being printed after PheroParseError

### DIFF
--- a/packages/core/src/domain/errors.ts
+++ b/packages/core/src/domain/errors.ts
@@ -14,7 +14,7 @@ export class MissingPheroFileError extends Error {
 }
 
 export class PheroParseError extends Error {
-  constructor(message: string, public readonly node: ts.Node) {
+  constructor(message: string, node: ts.Node) {
     super(generateErrorMessage(message, node))
   }
 }


### PR DESCRIPTION
This fixes that an enormous ts.Node object would be printed after pretty-printing a PheroParseError.