### PR TITLE
implements the PheroRequest utility type

### DIFF
--- a/packages/core/src/domain/PheroApp.ts
+++ b/packages/core/src/domain/PheroApp.ts
@@ -61,12 +61,14 @@ export interface PheroFunctionParameter {
 
 export interface PheroServiceConfig {
   middleware: PheroMiddlewareConfig[]
+  isRequestPopulated?: boolean
   contextType?: ts.TypeLiteralNode
   contextTypeModel?: ObjectParserModel
 }
 
 export interface PheroMiddlewareConfig {
   middleware: ts.FunctionLikeDeclarationBase
+  isRequestPopulated?: boolean
   contextType?: ts.TypeNode
   contextTypeModel: ObjectParserModel
   nextType?: ts.TypeNode

--- a/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
+++ b/packages/core/src/generateModel/generateFromDeclaration/generateFromDeclaration.ts
@@ -187,6 +187,9 @@ function generateFromDeclarationWithDeclaration(
   }
 
   if (ts.isTypeAliasDeclaration(declaration)) {
+    if (isPheroRequestReference(typeNode)) {
+      return { root: { type: ParserModelType.Unchecked }, deps }
+    }
     if (isPheroUncheckedReference(typeNode)) {
       if (!isPheroUncheckedAllowed(typeNode)) {
         throw new PheroParseError(
@@ -194,7 +197,6 @@ function generateFromDeclarationWithDeclaration(
           typeNode,
         )
       }
-
       return { root: { type: ParserModelType.Unchecked }, deps }
     }
 
@@ -523,6 +525,14 @@ function isPheroUncheckedReference(typeNode: ts.TypeNode): boolean {
     ts.isTypeReferenceNode(typeNode) &&
     ts.isIdentifier(typeNode.typeName) &&
     typeNode.typeName.text === "PheroUnchecked"
+  )
+}
+
+function isPheroRequestReference(typeNode: ts.TypeNode): boolean {
+  return (
+    ts.isTypeReferenceNode(typeNode) &&
+    ts.isIdentifier(typeNode.typeName) &&
+    typeNode.typeName.text === "PheroRequest"
   )
 }
 

--- a/packages/core/src/parsePheroApp/parseServiceDefinition.ts
+++ b/packages/core/src/parsePheroApp/parseServiceDefinition.ts
@@ -69,7 +69,10 @@ function generateServiceContextProps(
   serviceContext: ServiceContext | undefined,
   typeChecker: ts.TypeChecker,
   deps: DependencyMap,
-): Pick<PheroServiceConfig, "contextType" | "contextTypeModel"> {
+): Pick<
+  PheroServiceConfig,
+  "isRequestPopulated" | "contextType" | "contextTypeModel"
+> {
   if (!serviceContext) {
     return {}
   }
@@ -85,6 +88,7 @@ function generateServiceContextProps(
   )
 
   return {
+    isRequestPopulated: serviceContext.isRequestPopulated,
     contextType,
     contextTypeModel,
   }

--- a/packages/server/src/commands/export/gcloud-functions/generateLibFile.ts
+++ b/packages/server/src/commands/export/gcloud-functions/generateLibFile.ts
@@ -11,8 +11,23 @@ export default function generateLibFile(): ts.Node[] {
     return { functionName };
 }
 
-export async function readBody(request: any) {
+function readBody(request: any) {
     return request.body ?? {}
+}
+
+export async function createInput(req: any, isRequestPopulated: boolean): any {
+    const body = readBody(req)
+    if (!isRequestPopulated) {
+        return body
+    }
+    const { context, ...props } = body
+    return {
+        context: {
+            ...context,
+            req,
+        },
+        ...props,
+    }
 }
 
 export async function writeResponse(

--- a/packages/server/src/commands/export/gcloud-functions/generateServiceHandlerFile.ts
+++ b/packages/server/src/commands/export/gcloud-functions/generateServiceHandlerFile.ts
@@ -9,7 +9,7 @@ import {
 export function generateServiceHandlerFile(service: PheroService): ts.Node[] {
   return [
     tsx.importDeclaration({
-      names: ["writeResponse", "parseServiceAndFunction", "readBody"],
+      names: ["writeResponse", "parseServiceAndFunction", "createInput"],
       module: "./lib",
     }),
     tsx.importDeclaration({
@@ -112,8 +112,13 @@ function switchService(service: PheroService): ts.Statement {
         tsx.const({
           name: `${func.name}Data`,
           init: tsx.expression.await(
-            tsx.expression.call("readBody", {
-              args: ["req"],
+            tsx.expression.call("createInput", {
+              args: [
+                "req",
+                service.config.isRequestPopulated
+                  ? tsx.literal.true
+                  : tsx.literal.false,
+              ],
             }),
           ),
         }),

--- a/packages/server/src/commands/export/nodejs/generateLibFile.ts
+++ b/packages/server/src/commands/export/nodejs/generateLibFile.ts
@@ -11,7 +11,7 @@ export default function generateLibFile(): ts.Node[] {
     return { serviceName, functionName };
 }
 
-export async function readBody(request: any) {
+async function readBody(request: any) {
     return new Promise((resolve, reject) => {
         const chunks = []
         request
@@ -25,6 +25,21 @@ export async function readBody(request: any) {
             reject(err)
             })
         })
+}
+
+export async function createInput(req: any, isRequestPopulated: boolean): any {
+    const body = await readBody(req)
+    if (!isRequestPopulated) {
+        return body
+    }
+    const { context, ...props } = body
+    return {
+        context: {
+            ...context,
+            req,
+        },
+        ...props,
+    }
 }
 
 export async function writeResponse(

--- a/packages/server/src/commands/export/nodejs/generateServiceHandlerFile.ts
+++ b/packages/server/src/commands/export/nodejs/generateServiceHandlerFile.ts
@@ -9,7 +9,7 @@ import {
 export function generateServiceHandlerFile(service: PheroService): ts.Node[] {
   return [
     tsx.importDeclaration({
-      names: ["writeResponse", "parseServiceAndFunction", "readBody"],
+      names: ["writeResponse", "parseServiceAndFunction", "createInput"],
       module: "./lib",
     }),
     tsx.importDeclaration({
@@ -128,8 +128,13 @@ function switchService(service: PheroService): ts.Statement {
             tsx.expression.call(functionExecutor(service, func), {
               args: [
                 tsx.expression.await(
-                  tsx.expression.call("readBody", {
-                    args: ["req"],
+                  tsx.expression.call("createInput", {
+                    args: [
+                      "req",
+                      service.config.isRequestPopulated
+                        ? tsx.literal.true
+                        : tsx.literal.false,
+                    ],
                   }),
                 ),
               ],

--- a/packages/server/src/commands/export/vercel/generateLibFile.ts
+++ b/packages/server/src/commands/export/vercel/generateLibFile.ts
@@ -11,8 +11,23 @@ export default function generateLibFile(): ts.Node[] {
     return { serviceName, functionName };
 }
 
-export async function readBody(request: any) {
+function readBody(request: any) {
     return request.body ?? {}
+}
+
+export async function createInput(req: any, isRequestPopulated: boolean): any {
+    const body = readBody(req)
+    if (!isRequestPopulated) {
+        return body
+    }
+    const { context, ...props } = body
+    return {
+        context: {
+            ...context,
+            req,
+        },
+        ...props,
+    }
 }
 
 export async function writeResponse(

--- a/packages/server/src/commands/export/vercel/generateServiceHandlerFile.ts
+++ b/packages/server/src/commands/export/vercel/generateServiceHandlerFile.ts
@@ -9,7 +9,7 @@ import {
 export function generateServiceHandlerFile(service: PheroService): ts.Node[] {
   return [
     tsx.importDeclaration({
-      names: ["writeResponse", "parseServiceAndFunction", "readBody"],
+      names: ["writeResponse", "parseServiceAndFunction", "createInput"],
       module: "./lib",
     }),
     tsx.importDeclaration({
@@ -126,8 +126,13 @@ function switchService(service: PheroService): ts.Statement {
         tsx.const({
           name: `${func.name}Data`,
           init: tsx.expression.await(
-            tsx.expression.call("readBody", {
-              args: ["req"],
+            tsx.expression.call("createInput", {
+              args: [
+                "req",
+                service.config.isRequestPopulated
+                  ? tsx.literal.true
+                  : tsx.literal.false,
+              ],
             }),
           ),
         }),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,7 @@ export {
   RPCResult,
   DataParseError,
 } from "@phero/core/runtime"
+import { IncomingMessage } from "http"
 
 export type PheroServiceFunctions = Record<string, Function>
 
@@ -25,6 +26,8 @@ export type PheroMiddlewareFunction<C, N> = (
   ctx: PheroContext<C>,
   next: PheroNextFunction<N>,
 ) => Promise<void>
+
+export type PheroRequest = PheroUnchecked<IncomingMessage>
 
 export interface PheroServiceConfig {
   middleware: PheroMiddlewareFunction<any, void>[]


### PR DESCRIPTION
Building further upon #138 (PheroUnchecked), this utility type utilizes PheroUnchecked. When the user adds this to the middleware context Phero will populate the context automatically with the NodeJS' underlying `IncomingMessage` (aka. the request). A user can use this to retrieve data from the request (like headers). Like so:

```
import { PheroContext, PheroRequest, PheroNextFunction, createService } from "@phero/server"

async function getArticle(ctx: PheroContext<{ ip: string }>): Promise<string> {
  return ctx.ip
}

async function myMiddleware(ctx: PheroContext<{ req: PheroRequest }>, next: PheroNextFunction<{ ip: string }>) {
  const ip = ctx.req.headers["x-forwarded-for"]

  if (typeof ip !== "string") {
    throw new Error("IP should be a string")
  }

  await next({ ip })
}

export const articleService = createService({
  getArticle,
}, {
  middleware: [myMiddleware]
})
```

Some limitations:
* for now is that the property should be named "req" and not "request" or something else
* you can not directly use `req: PheroRequest` in a function, only in middleware